### PR TITLE
Fix hospital countdown noise for 'an' article countries

### DIFF
--- a/internal/processing/hospital_normalization_test.go
+++ b/internal/processing/hospital_normalization_test.go
@@ -47,6 +47,16 @@ func TestNormalizeHospitalDescription(t *testing.T) {
 			description: "In a Swiss hospital for 1hr 20mins",
 			expected:    "In hospital",
 		},
+		{
+			name:        "Emirati hospital with countdown (uses 'an')",
+			description: "In an Emirati hospital for 25 mins",
+			expected:    "In hospital",
+		},
+		{
+			name:        "American hospital with countdown (uses 'an')",
+			description: "In an American hospital for 45 mins",
+			expected:    "In hospital",
+		},
 		// Case variations
 		{
 			name:        "Mixed case country hospital",
@@ -102,12 +112,12 @@ func TestNormalizeHospitalDescription(t *testing.T) {
 func TestHospitalCountdownStateChangeIgnored(t *testing.T) {
 	service := NewStateChangeDetectionService(nil)
 
-	// Create two member states representing the bug scenario
+	// Create two member states representing the bug scenario with "an" article
 	oldMember := app.FactionMember{
-		Name:  "fangYuannn",
+		Name:  "testMember",
 		Level: 50,
 		Status: app.MemberStatus{
-			Description: "In a South African hospital for 33 mins",
+			Description: "In an Emirati hospital for 25 mins",
 			State:       "Hospital",
 			Color:       "red",
 			Details:     "Mugged by someone",
@@ -118,10 +128,10 @@ func TestHospitalCountdownStateChangeIgnored(t *testing.T) {
 	}
 
 	newMember := app.FactionMember{
-		Name:  "fangYuannn",
+		Name:  "testMember",
 		Level: 50,
 		Status: app.MemberStatus{
-			Description: "In a South African hospital for 28 mins", // Countdown decreased
+			Description: "In an Emirati hospital for 21 mins", // Countdown decreased
 			State:       "Hospital",
 			Color:       "red",
 			Details:     "Mugged by someone",

--- a/internal/processing/state_change_service.go
+++ b/internal/processing/state_change_service.go
@@ -26,9 +26,9 @@ func NewStateChangeDetectionService(sheetsClient SheetsClientInterface) *StateCh
 
 // NormalizeHospitalDescription removes countdown from hospital descriptions for comparison
 func (scds *StateChangeDetectionService) NormalizeHospitalDescription(description string) string {
-	// Match "In hospital for X hrs Y mins" and "In a [Country/Countries] hospital for X mins" patterns
-	// Handles single words (British, Mexican) and multi-word countries (South African)
-	hospitalRegex := regexp.MustCompile(`(?i)^in\s+(a\s+[\w\s]+\s+)?hospital(\s+for\s+.*)?$`)
+	// Match "In hospital for X hrs Y mins" and "In a/an [Country/Countries] hospital for X mins" patterns
+	// Handles single words (British, Mexican, Emirati) and multi-word countries (South African)
+	hospitalRegex := regexp.MustCompile(`(?i)^in\s+(an?\s+[\w\s]+\s+)?hospital(\s+for\s+.*)?$`)
 	if hospitalRegex.MatchString(description) {
 		return "In hospital"
 	}

--- a/internal/processing/status_v2_service_test.go
+++ b/internal/processing/status_v2_service_test.go
@@ -20,8 +20,6 @@ func TestParseStateRecordFromRow(t *testing.T) {
 			name: "complete row with travel type",
 			row: []interface{}{
 				"2022-01-01 00:00:00",        // Timestamp
-				"2022-01-01",                 // Date
-				"00:00:00",                   // Time
 				"12345",                      // Member ID
 				"TestPlayer",                 // Member Name
 				"1001",                       // Faction ID
@@ -49,8 +47,6 @@ func TestParseStateRecordFromRow(t *testing.T) {
 			name: "row without travel type",
 			row: []interface{}{
 				"2022-01-01 00:00:00",        // Timestamp
-				"2022-01-01",                 // Date
-				"00:00:00",                   // Time
 				"12346",                      // Member ID
 				"TestPlayer2",                // Member Name
 				"1001",                       // Faction ID
@@ -77,8 +73,6 @@ func TestParseStateRecordFromRow(t *testing.T) {
 			name: "row with regular travel type",
 			row: []interface{}{
 				"2022-01-01 00:00:00",        // Timestamp
-				"2022-01-01",                 // Date
-				"00:00:00",                   // Time
 				"12347",                      // Member ID
 				"TestPlayer3",                // Member Name
 				"1001",                       // Faction ID
@@ -151,8 +145,6 @@ func TestTravelSpeedBugFix(t *testing.T) {
 	// Test that airstrip travel type is preserved and not overwritten with empty string
 	row := []interface{}{
 		"2022-01-01 00:00:00",        // Timestamp
-		"2022-01-01",                 // Date
-		"00:00:00",                   // Time
 		"12345",                      // Member ID
 		"TestPlayer",                 // Member Name
 		"1001",                       // Faction ID
@@ -176,7 +168,7 @@ func TestTravelSpeedBugFix(t *testing.T) {
 	}
 
 	// Test regular travel too
-	row[11] = "regular"
+	row[9] = "regular"
 	record, err = service.parseStateRecordFromRow(row)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)

--- a/internal/processing/travel_time_service_test.go
+++ b/internal/processing/travel_time_service_test.go
@@ -229,7 +229,7 @@ func TestTravelTimeServiceCalculateTravelTimesFromDeparture(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tts.CalculateTravelTimesFromDeparture(
 				ctx, tt.userID, tt.destination, tt.departureStr,
-				tt.existingArrivalStr, tt.travelType, currentTime, ls,
+				tt.existingArrivalStr, tt.travelType, currentTime, ls, "",
 			)
 
 			if tt.expectNil {


### PR DESCRIPTION
## Summary
- Fix duplicate Changed States records for hospital countdown decrements
- Resolve regex bug that only matched "In a [country] hospital" but not "In an [country] hospital" 
- Eliminate noise from countries using 'an' article (Emirati, American, etc.)

## Root Cause
The hospital normalization regex pattern `(a\s+[\w\s]+\s+)?` only matched "a" articles, causing countries that use "an" (Emirati, American, etc.) to bypass normalization. This meant every countdown decrement was treated as a state change, creating duplicate records like:

```
In an Emirati hospital for 25 mins
In an Emirati hospital for 23 mins  
In an Emirati hospital for 21 mins
```

## Changes Made
- Update regex from `(a\s+[\w\s]+\s+)?` to `(an?\s+[\w\s]+\s+)?` to match both 'a' and 'an'
- Add comprehensive test coverage for Emirati and American hospitals using 'an' article
- Update test scenario to use the actual reported bug case (Emirati hospital)
- Fix broken tests that used outdated Changed States sheet column format

## Test Results
- ✅ `TestNormalizeHospitalDescription` - All patterns including 'an' articles
- ✅ `TestHospitalCountdownStateChangeIgnored` - Emirati hospital countdown ignored  
- ✅ `TestParseStateRecordFromRow` - Fixed column mapping
- ✅ `TestTravelSpeedBugFix` - Travel types preserved correctly
- ✅ All tests passing: `ok torn_rw_stats/internal/processing 0.496s`

## Test plan
- [x] Hospital countdown decrements for "an" countries no longer create duplicate records
- [x] All existing hospital normalization patterns still work
- [x] Real state changes (hospital → okay, color changes) still detected
- [x] All tests pass with comprehensive coverage

🤖 Generated with [Claude Code](https://claude.ai/code)