### PR TITLE
Fix blank row accumulation in Status sheets

### DIFF
--- a/internal/sheets/state_manager.go
+++ b/internal/sheets/state_manager.go
@@ -223,9 +223,9 @@ func (m *StateChangeManager) StorePreviousMemberStates(ctx context.Context, spre
 		return fmt.Errorf("failed to ensure sheet capacity: %w", err)
 	}
 
-	// Write the data starting from row 2
-	dataRangeSpec := fmt.Sprintf("%s!A2", sheetName)
-	if err := m.api.AppendRows(ctx, spreadsheetID, dataRangeSpec, rows); err != nil {
+	// Write the data starting from row 2 using UpdateRange to avoid blank row accumulation
+	dataRangeSpec := fmt.Sprintf("%s!A2:I%d", sheetName, len(rows)+1)
+	if err := m.api.UpdateRange(ctx, spreadsheetID, dataRangeSpec, rows); err != nil {
 		return fmt.Errorf("failed to store previous member states: %w", err)
 	}
 

--- a/internal/sheets/status_v2_manager.go
+++ b/internal/sheets/status_v2_manager.go
@@ -119,9 +119,9 @@ func (m *StatusV2Manager) UpdateStatusV2(ctx context.Context, spreadsheetID, she
 		return fmt.Errorf("failed to ensure sheet capacity: %w", err)
 	}
 
-	// Write the data starting from row 2
-	dataRangeSpec := fmt.Sprintf("%s!A2", sheetName)
-	if err := m.api.AppendRows(ctx, spreadsheetID, dataRangeSpec, rows); err != nil {
+	// Write the data starting from row 2 using UpdateRange to avoid blank row accumulation
+	dataRangeSpec := fmt.Sprintf("%s!A2:H%d", sheetName, len(rows)+1)
+	if err := m.api.UpdateRange(ctx, spreadsheetID, dataRangeSpec, rows); err != nil {
 		return fmt.Errorf("failed to update Status v2 records: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- Fixed infinite blank row growth in Status v2 sheets and Previous States sheets
- Replaced `AppendRows` with `UpdateRange` after `ClearRange` operations
- Prevents hitting Google Sheets row limits due to accumulating blank rows

## Problem
The current pattern of `ClearRange()` + `AppendRows()` was causing blank row accumulation:
1. `ClearRange()` clears content but leaves blank rows in place
2. `AppendRows()` with `INSERT_ROWS` option adds new rows below existing ones
3. Each update cycle adds more blank rows, eventually hitting sheet limits

## Solution
Switched to `UpdateRange()` which overwrites the specific range without creating additional rows:
- StatusV2Manager: `A2:H{end_row}` range specification
- StateChangeManager: `A2:I{end_row}` range specification

## Files Changed
- `internal/sheets/status_v2_manager.go`: Fixed UpdateStatusV2 method
- `internal/sheets/state_manager.go`: Fixed StorePreviousMemberStates method

## Testing
- All existing tests pass
- No behavioral changes to data writing, only prevents blank row growth

🤖 Generated with [Claude Code](https://claude.ai/code)