### PR TITLE
Update golangci-lint path in release process documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ When making changes and preparing for release, follow this standardized process:
 
 5. **Run golangci-lint** - Fix all linting issues:
    ```bash
-   golangci-lint run
+   $HOME/go/bin/golangci-lint run
    ```
 
 ### Release Workflow


### PR DESCRIPTION
## Summary
Updates the release process documentation to use the correct path for golangci-lint.

## Changes
- Changed from `golangci-lint run` to `$HOME/go/bin/golangci-lint run`
- Uses `$HOME` environment variable for portability across different systems

## Context
During the recent release process, we discovered that `golangci-lint` is not in the system PATH by default and requires the full path to execute. This updates the documentation to reflect the correct command that actually works.

## Impact
- Documentation now matches the actual working command
- Future releases will have the correct instructions
- No functional code changes

🤖 Generated with [Claude Code](https://claude.ai/code)