### PR TITLE
Add clickable member profile links to tactical dashboard

### DIFF
--- a/tactical_dashboard.html
+++ b/tactical_dashboard.html
@@ -191,6 +191,17 @@
             font-weight: 500;
         }
 
+        .member-link {
+            color: #4a90e2;
+            text-decoration: none;
+            transition: color 0.2s;
+        }
+
+        .member-link:hover {
+            color: #357abd;
+            text-decoration: underline;
+        }
+
         .member-status {
             color: #666;
             font-size: 0.9em;
@@ -434,10 +445,15 @@
             const memberKey = `${locationId}-${member.Name.replace(/\s+/g, '-')}`;
             const countdownId = `countdown-${memberKey}`;
 
+            // Create member name with profile link if MemberID is available
+            const memberNameHtml = member.MemberID
+                ? `<a href="https://www.torn.com/profiles.php?XID=${member.MemberID}" target="_blank" class="member-link">${member.Name}</a>`
+                : member.Name;
+
             return `
                 <div class="member-row">
                     <div class="status-dot ${statusClass}"></div>
-                    <div class="member-name">${member.Name}</div>
+                    <div class="member-name">${memberNameHtml}</div>
                     ${statusText ? `<div class="member-status">${statusText}</div>` : ''}
                     ${countdown ? `<div class="member-countdown ${countdownClass}" id="${countdownId}" data-initial-countdown="${countdown}">${countdown}</div>` : ''}
                 </div>


### PR DESCRIPTION
## Summary
- Member names in the tactical dashboard are now clickable links that open Torn profile pages
- Uses the newly added MemberID field from the JSON data structure

## Changes
- Added CSS styling for `.member-link` class with hover effects
- Updated `createMemberRow()` function to generate profile links using `member.MemberID`
- Links use the format: `https://www.torn.com/profiles.php?XID={MemberID}`
- Links open in new tab/window (`target="_blank"`) for better UX
- Graceful fallback to plain text if MemberID is not available

## Test plan
- [x] Code changes implemented
- [x] CSS styling provides clear visual feedback on hover
- [x] Links generate correct Torn profile URLs
- [x] Fallback works when MemberID is missing
- [x] Links open in new tab as expected

## Dependencies
- Requires the MemberID field to be present in the JSON data (added in previous PR)

🤖 Generated with [Claude Code](https://claude.ai/code)