### PR TITLE
Add Until and Arrival fields with dual countdown display

### DIFF
--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -263,6 +263,7 @@ type JSONMember struct {
 	Status    string `json:"Status,omitempty"`
 	Countdown string `json:"Countdown,omitempty"`
 	Until     string `json:"Until,omitempty"`
+	Arrival   string `json:"Arrival,omitempty"`
 }
 
 // LocationData represents the traveling and located members for a location

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -243,15 +243,16 @@ type StateRecord struct {
 
 // StatusV2Record represents a member's data for Status v2 sheets
 type StatusV2Record struct {
-	Name      string `json:"name"`
-	MemberID  string `json:"member_id"`
-	Level     int    `json:"level"`
-	State     string `json:"state"`     // LastActionStatus from StateRecord
-	Status    string `json:"status"`    // StatusDescription from StateRecord
-	Location  string `json:"location"`  // Destination for traveling, otherwise current location
-	Countdown string `json:"countdown"` // Calculated from StatusUntil field
-	Departure string `json:"departure"` // Manual adjustment preserved
-	Arrival   string `json:"arrival"`   // Manual adjustment preserved
+	Name      string    `json:"name"`
+	MemberID  string    `json:"member_id"`
+	Level     int       `json:"level"`
+	State     string    `json:"state"`     // LastActionStatus from StateRecord
+	Status    string    `json:"status"`    // StatusDescription from StateRecord
+	Location  string    `json:"location"`  // Destination for traveling, otherwise current location
+	Countdown string    `json:"countdown"` // Calculated from StatusUntil field
+	Departure string    `json:"departure"` // Manual adjustment preserved
+	Arrival   string    `json:"arrival"`   // Manual adjustment preserved
+	Until     time.Time `json:"until"`     // StatusUntil timestamp from StateRecord
 }
 
 // JSONMember represents a member in the JSON export format
@@ -261,6 +262,7 @@ type JSONMember struct {
 	State     string `json:"State"`
 	Status    string `json:"Status,omitempty"`
 	Countdown string `json:"Countdown,omitempty"`
+	Until     string `json:"Until,omitempty"`
 }
 
 // LocationData represents the traveling and located members for a location

--- a/internal/application/services/status_v2_service.go
+++ b/internal/application/services/status_v2_service.go
@@ -464,6 +464,10 @@ func (s *StatusV2Service) ConvertToJSON(records []app.StatusV2Record, factionNam
 			if record.Countdown != "" && record.Countdown != "00:00:00" {
 				member.Countdown = strings.TrimPrefix(record.Countdown, "'")
 			}
+			// Add arrival time for traveling members
+			if record.Arrival != "" {
+				member.Arrival = record.Arrival
+			}
 			// Add to traveling array
 			locationData := locations[location]
 			locationData.Traveling = append(locationData.Traveling, member)

--- a/tactical_dashboard.html
+++ b/tactical_dashboard.html
@@ -230,6 +230,8 @@
             color: #333;
             min-width: 70px;
             text-align: center;
+            margin-right: 8px;
+            margin-bottom: 4px;
         }
 
         .member-countdown.warning {
@@ -240,6 +242,13 @@
         .member-countdown.urgent {
             background: #FFC107;
             color: #000;
+        }
+
+        /* Style for countdown containers */
+        .countdown-container {
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
         }
 
         .expand-icon {
@@ -375,9 +384,10 @@
 
             // Initialize countdown end times from DOM elements
             countdownTimers.clear();
-            const countdownElements = document.querySelectorAll('.member-countdown[data-initial-countdown]');
             const currentTime = Date.now();
 
+            // Handle original countdown elements
+            const countdownElements = document.querySelectorAll('.member-countdown[data-initial-countdown]');
             countdownElements.forEach(element => {
                 const initialCountdown = element.getAttribute('data-initial-countdown');
                 if (initialCountdown && initialCountdown !== '0:00:00') {
@@ -385,6 +395,19 @@
                     if (totalSeconds > 0) {
                         const endTime = currentTime + (totalSeconds * 1000);
                         countdownTimers.set(element.id, endTime);
+                    }
+                }
+            });
+
+            // Handle arrival-based countdown elements
+            const arrivalElements = document.querySelectorAll('.member-countdown[data-arrival-time]');
+            arrivalElements.forEach(element => {
+                const arrivalTimeStr = element.getAttribute('data-arrival-time');
+                if (arrivalTimeStr) {
+                    // Parse arrival time (format: "2025-09-17 14:23:45")
+                    const arrivalTime = new Date(arrivalTimeStr.replace(' ', 'T') + 'Z').getTime();
+                    if (!isNaN(arrivalTime)) {
+                        countdownTimers.set(element.id, arrivalTime);
                     }
                 }
             });
@@ -406,7 +429,13 @@
 
                 const remainingMs = endTime - currentTime;
                 if (remainingMs <= 0) {
-                    element.textContent = '0:00:00';
+                    // Find the time display div (second child)
+                    const timeDiv = element.children[1];
+                    if (timeDiv) {
+                        timeDiv.textContent = '0:00:00';
+                    } else {
+                        element.textContent = '0:00:00';
+                    }
                     element.className = 'member-countdown warning';
                     countdownTimers.delete(countdownId);
                 } else {
@@ -414,8 +443,13 @@
                     const remainingSeconds = Math.floor(remainingMs / 1000);
                     const timeString = formatSecondsToTime(remainingSeconds);
 
-                    // Update the countdown text
-                    element.textContent = timeString;
+                    // Update the countdown text - check if we have nested structure
+                    const timeDiv = element.children[1];
+                    if (timeDiv) {
+                        timeDiv.textContent = timeString;
+                    } else {
+                        element.textContent = timeString;
+                    }
 
                     // Update the color class based on remaining time
                     const remainingMinutes = Math.floor(remainingSeconds / 60);
@@ -457,18 +491,42 @@
             // Create unique ID for this member's countdown
             const memberKey = `${locationId}-${member.Name.replace(/\s+/g, '-')}`;
             const countdownId = `countdown-${memberKey}`;
+            const arrivalCountdownId = `arrival-countdown-${memberKey}`;
 
             // Create member name with profile link and attack link if MemberID is available
             const memberNameHtml = member.MemberID
                 ? `<a href="https://www.torn.com/profiles.php?XID=${member.MemberID}" target="_blank" class="member-link">${member.Name}</a><a href="https://www.torn.com/loader.php?sid=attack&user2ID=${member.MemberID}" target="_blank" class="attack-link" title="Attack ${member.Name}">🔫</a>`
                 : member.Name;
 
+            // Build countdown displays
+            let countdownHtml = '';
+            if (countdown || member.Arrival) {
+                countdownHtml = '<div class="countdown-container">';
+
+                if (countdown) {
+                    countdownHtml += `<div class="member-countdown ${countdownClass}" id="${countdownId}" data-initial-countdown="${countdown}">
+                        <div style="font-size: 0.8em; color: #666;">Original:</div>
+                        <div>${countdown}</div>
+                    </div>`;
+                }
+
+                // Add arrival-based countdown if available
+                if (member.Arrival) {
+                    countdownHtml += `<div class="member-countdown" id="${arrivalCountdownId}" data-arrival-time="${member.Arrival}">
+                        <div style="font-size: 0.8em; color: #666;">Calculated:</div>
+                        <div>Calculating...</div>
+                    </div>`;
+                }
+
+                countdownHtml += '</div>';
+            }
+
             return `
                 <div class="member-row">
                     <div class="status-dot ${statusClass}"></div>
                     <div class="member-name">${memberNameHtml}</div>
                     ${statusText ? `<div class="member-status">${statusText}</div>` : ''}
-                    ${countdown ? `<div class="member-countdown ${countdownClass}" id="${countdownId}" data-initial-countdown="${countdown}">${countdown}</div>` : ''}
+                    ${countdownHtml}
                 </div>
             `;
         }


### PR DESCRIPTION
## Summary

- Add `Until` field to JSON member data providing raw StatusUntil timestamp
- Add `Arrival` field to JSON member data providing calculated arrival time
- Implement dual countdown display on tactical dashboard for accuracy testing

## Backend Changes

### New JSON Fields
- **`Until`**: ISO timestamp from StatusUntil field (`"2025-09-17T14:23:45Z"`)
- **`Arrival`**: Calculated arrival time (`"2025-09-17 14:23:45"`) for traveling members only

### Data Flow
1. `StatusUntil` timestamp from StateRecord → `StatusV2Record.Until`
2. Travel time calculation → `StatusV2Record.Arrival` 
3. JSON export includes both fields for frontend consumption

### Sheet Integration
- Add "Until" column to Status v2 sheets
- Update range specifications from `A2:H` to `A2:I`
- Backward-compatible parsing for existing sheets

## Frontend Changes

### Dual Countdown Display
Each traveling member now shows **two countdowns** for comparison:
- **"Original"**: Ticks down from initial `Countdown` field
- **"Calculated"**: Live diff between `Arrival` timestamp and current time

### Benefits
- Enables accuracy testing between countdown calculation methods
- Provides real-time arrival timestamp access for frontend features
- Maintains backward compatibility with existing countdown logic

## Test Plan

- [ ] Verify both countdowns show similar initial times
- [ ] Test countdown accuracy over time periods
- [ ] Check timezone handling and edge cases
- [ ] Validate sheet updates include new Until column
- [ ] Test backward compatibility with existing data

🤖 Generated with [Claude Code](https://claude.ai/code)