### PR TITLE
Add dual countdown support for hospital and jail members

### DIFF
--- a/tactical_dashboard.html
+++ b/tactical_dashboard.html
@@ -412,6 +412,19 @@
                 }
             });
 
+            // Handle until-based countdown elements (for hospital/jail)
+            const untilElements = document.querySelectorAll('.member-countdown[data-until-time]');
+            untilElements.forEach(element => {
+                const untilTimeStr = element.getAttribute('data-until-time');
+                if (untilTimeStr) {
+                    // Parse until time (format: "2025-09-17T14:23:45Z")
+                    const untilTime = new Date(untilTimeStr).getTime();
+                    if (!isNaN(untilTime)) {
+                        countdownTimers.set(element.id, untilTime);
+                    }
+                }
+            });
+
             // Start the countdown update interval
             countdownIntervalId = setInterval(updateCountdowns, 1000);
         }
@@ -492,6 +505,7 @@
             const memberKey = `${locationId}-${member.Name.replace(/\s+/g, '-')}`;
             const countdownId = `countdown-${memberKey}`;
             const arrivalCountdownId = `arrival-countdown-${memberKey}`;
+            const untilCountdownId = `until-countdown-${memberKey}`;
 
             // Create member name with profile link and attack link if MemberID is available
             const memberNameHtml = member.MemberID
@@ -500,7 +514,7 @@
 
             // Build countdown displays
             let countdownHtml = '';
-            if (countdown || member.Arrival) {
+            if (countdown || member.Arrival || member.Until) {
                 countdownHtml = '<div class="countdown-container">';
 
                 if (countdown) {
@@ -510,9 +524,17 @@
                     </div>`;
                 }
 
-                // Add arrival-based countdown if available
+                // Add arrival-based countdown if available (for traveling members)
                 if (member.Arrival) {
                     countdownHtml += `<div class="member-countdown" id="${arrivalCountdownId}" data-arrival-time="${member.Arrival}">
+                        <div style="font-size: 0.8em; color: #666;">Calculated:</div>
+                        <div>Calculating...</div>
+                    </div>`;
+                }
+
+                // Add until-based countdown if available (for hospital/jail members)
+                if (member.Until && !member.Arrival) {
+                    countdownHtml += `<div class="member-countdown" id="${untilCountdownId}" data-until-time="${member.Until}">
                         <div style="font-size: 0.8em; color: #666;">Calculated:</div>
                         <div>Calculating...</div>
                     </div>`;


### PR DESCRIPTION
## Summary

Extend the dual countdown feature to show both original and calculated countdowns for located members (hospital, jail, etc.) using the Until field.

## Background

The dual countdown feature currently only works for traveling members using the Arrival field. Hospital and jail members also have timed statuses that can benefit from the same accuracy testing approach.

## Changes

### Frontend Updates
- Add Until-based countdown display for non-traveling members
- Create unique countdown IDs for until-based timers (`until-countdown-{memberKey}`)
- Handle Until field parsing (ISO format: `"2025-09-17T14:23:45Z"`)
- Show dual countdowns when member has Until timestamp
- Maintain existing traveling member logic with Arrival field

### Display Logic
- **Traveling members**: Show "Original" vs "Calculated" (from Arrival timestamp)
- **Located members**: Show "Original" vs "Calculated" (from Until timestamp)  
- **Members with neither**: Show only original countdown (if any)

## Testing Capabilities

This enables comprehensive countdown accuracy testing for:
- ✅ **Travel countdowns** (departure/arrival scenarios)
- ✅ **Hospital countdowns** (release time scenarios)
- ✅ **Jail countdowns** (release time scenarios)
- ✅ **Any timed status** with Until field

## Technical Details

- Until field contains ISO timestamps: `"2025-09-17T14:23:45Z"`
- Smart logic prevents showing both Arrival and Until countdowns simultaneously
- Reuses existing countdown update infrastructure
- Maintains backward compatibility

## Benefits

- **Comprehensive testing**: Compare countdown accuracy across all game scenarios
- **Better user experience**: Consistent dual countdown interface
- **Data-driven decisions**: Test which countdown method is more accurate for different status types

🤖 Generated with [Claude Code](https://claude.ai/code)