### PR TITLE
Add Business Class travel support

### DIFF
--- a/internal/domain/travel/travel_time_property_test.go
+++ b/internal/domain/travel/travel_time_property_test.go
@@ -23,7 +23,7 @@ func TestTravelTimeServiceProperties(t *testing.T) {
 			return duration > 0
 		},
 		gen.OneConstOf("Mexico", "United Kingdom", "Switzerland", "Hawaii", "Canada", "UnknownPlace"),
-		gen.OneConstOf("regular", "airstrip"),
+		gen.OneConstOf("regular", "airstrip", "business"),
 	))
 
 	// Property: Airstrip travel should be faster than regular travel for known destinations
@@ -38,6 +38,23 @@ func TestTravelTimeServiceProperties(t *testing.T) {
 			}
 
 			return airstripTime <= regularTime
+		},
+		gen.OneConstOf("Mexico", "United Kingdom", "Switzerland", "Hawaii", "Canada"),
+	))
+
+	// Property: Business class should be fastest travel type for known destinations
+	properties.Property("business class fastest", prop.ForAll(
+		func(destination string) bool {
+			regularTime := service.GetTravelTime(destination, "regular")
+			airstripTime := service.GetTravelTime(destination, "airstrip")
+			businessTime := service.GetTravelTime(destination, "business")
+
+			// For unknown destinations, all might return default, so skip those
+			if regularTime == 30*time.Minute && airstripTime == 30*time.Minute && businessTime == 30*time.Minute {
+				return true // Skip unknown destinations
+			}
+
+			return businessTime <= airstripTime && businessTime <= regularTime
 		},
 		gen.OneConstOf("Mexico", "United Kingdom", "Switzerland", "Hawaii", "Canada"),
 	))
@@ -107,8 +124,10 @@ func TestTravelTimeServiceProperties(t *testing.T) {
 			time2 := service.GetTravelTime(destination, "regular")
 			time3 := service.GetTravelTime(destination, "airstrip")
 			time4 := service.GetTravelTime(destination, "airstrip")
+			time5 := service.GetTravelTime(destination, "business")
+			time6 := service.GetTravelTime(destination, "business")
 
-			return time1 == time2 && time3 == time4
+			return time1 == time2 && time3 == time4 && time5 == time6
 		},
 		gen.OneConstOf("Mexico", "United Kingdom", "Switzerland", "Hawaii", "Canada"),
 	))

--- a/internal/domain/travel/travel_time_service.go
+++ b/internal/domain/travel/travel_time_service.go
@@ -10,8 +10,9 @@ import (
 
 // TravelTimeService handles travel time calculations and formatting
 type TravelTimeService struct {
-	regularTimes  map[string]int
-	airstripTimes map[string]int
+	regularTimes     map[string]int
+	airstripTimes    map[string]int
+	businessTimes    map[string]int
 }
 
 // NewTravelTimeService creates a new travel time service with predefined travel times
@@ -43,6 +44,21 @@ func NewTravelTimeService() *TravelTimeService {
 			"UAE":            190, // 3h 10m
 			"South Africa":   208, // 3h 28m
 		},
+		businessTimes: map[string]int{
+			// Business class travel times (fastest option)
+			// Note: API detection for business class is not yet implemented
+			"Mexico":         8,
+			"Cayman Islands": 11,
+			"Canada":         12,
+			"Hawaii":         40,
+			"United Kingdom": 48,
+			"Argentina":      50,
+			"Switzerland":    53,
+			"Japan":          68, // 1h 8m
+			"China":          72, // 1h 12m
+			"UAE":            81, // 1h 21m
+			"South Africa":   89, // 1h 29m
+		},
 	}
 }
 
@@ -54,11 +70,16 @@ type TravelTimeData struct {
 }
 
 // GetTravelTime returns travel duration based on destination and travel type
+// Travel types: "regular" (default), "airstrip" (private jet), "business" (business class)
+// Note: Business class detection from API is not currently implemented - this prepares the infrastructure
 func (tts *TravelTimeService) GetTravelTime(destination string, travelType string) time.Duration {
 	var minutes int
-	if travelType == "airstrip" {
+	switch travelType {
+	case "airstrip":
 		minutes = tts.airstripTimes[destination]
-	} else {
+	case "business":
+		minutes = tts.businessTimes[destination]
+	default:
 		minutes = tts.regularTimes[destination]
 	}
 


### PR DESCRIPTION
## Summary
- Add complete Business Class travel data for all destinations
- Implement infrastructure to support business class travel type detection  
- Prepare system for future business class detection logic

## Changes Made
- **Travel Time Data**: Added `businessTimes` map with all 11 destinations (8-89 minutes)
- **API Support**: Updated `GetTravelTime()` to handle `"business"` travel type
- **Speed Hierarchy**: Business Class (fastest) < Private Jet < Regular travel
- **Comprehensive Testing**: Added unit tests, integration tests, and property-based tests
- **Documentation**: Added comments noting API detection is not yet implemented

## Travel Time Examples
| Destination | Business | Private Jet | Regular |
|-------------|----------|-------------|---------|
| Mexico | 8 min | 18 min | 26 min |
| Switzerland | 53 min | 123 min | 175 min |
| Japan | 68 min | 158 min | 225 min |

## Infrastructure Preparation
- System ready to accept `"business"` travel type from API
- All calculation logic prepared for business class detection
- Tests verify business class is consistently fastest option
- Ready for future implementation of detection heuristics

## Notes
- Business class detection from API is not currently implemented
- This PR prepares the infrastructure as requested
- Future work can focus on detection logic without touching core travel time system

🤖 Generated with [Claude Code](https://claude.ai/code)