### PR TITLE
Add BusinessArrival support for business class travel detection

### DIFF
--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -197,13 +197,14 @@ type MemberStatus struct {
 
 // TravelRecord represents a member's travel status record
 type TravelRecord struct {
-	Name      string `json:"name"`
-	Level     int    `json:"level"`
-	Location  string `json:"location"`
-	State     string `json:"state"`
-	Departure string `json:"departure"`
-	Countdown string `json:"countdown"`
-	Arrival   string `json:"arrival"`
+	Name            string `json:"name"`
+	Level           int    `json:"level"`
+	Location        string `json:"location"`
+	State           string `json:"state"`
+	Departure       string `json:"departure"`
+	Countdown       string `json:"countdown"`
+	Arrival         string `json:"arrival"`
+	BusinessArrival string `json:"business_arrival"` // Alternative arrival time assuming business class
 }
 
 // StateChangeRecord represents a member's state change record
@@ -243,27 +244,29 @@ type StateRecord struct {
 
 // StatusV2Record represents a member's data for Status v2 sheets
 type StatusV2Record struct {
-	Name      string    `json:"name"`
-	MemberID  string    `json:"member_id"`
-	Level     int       `json:"level"`
-	State     string    `json:"state"`     // LastActionStatus from StateRecord
-	Status    string    `json:"status"`    // StatusDescription from StateRecord
-	Location  string    `json:"location"`  // Destination for traveling, otherwise current location
-	Countdown string    `json:"countdown"` // Calculated from StatusUntil field
-	Departure string    `json:"departure"` // Manual adjustment preserved
-	Arrival   string    `json:"arrival"`   // Manual adjustment preserved
-	Until     time.Time `json:"until"`     // StatusUntil timestamp from StateRecord
+	Name            string    `json:"name"`
+	MemberID        string    `json:"member_id"`
+	Level           int       `json:"level"`
+	State           string    `json:"state"`            // LastActionStatus from StateRecord
+	Status          string    `json:"status"`           // StatusDescription from StateRecord
+	Location        string    `json:"location"`         // Destination for traveling, otherwise current location
+	Countdown       string    `json:"countdown"`        // Calculated from StatusUntil field
+	Departure       string    `json:"departure"`        // Manual adjustment preserved
+	Arrival         string    `json:"arrival"`          // Manual adjustment preserved
+	BusinessArrival string    `json:"business_arrival"` // Alternative arrival time assuming business class
+	Until           time.Time `json:"until"`            // StatusUntil timestamp from StateRecord
 }
 
 // JSONMember represents a member in the JSON export format
 type JSONMember struct {
-	Name      string `json:"Name"`
-	MemberID  string `json:"MemberID"`
-	State     string `json:"State"`
-	Status    string `json:"Status,omitempty"`
-	Countdown string `json:"Countdown,omitempty"`
-	Until     string `json:"Until,omitempty"`
-	Arrival   string `json:"Arrival,omitempty"`
+	Name            string `json:"Name"`
+	MemberID        string `json:"MemberID"`
+	State           string `json:"State"`
+	Status          string `json:"Status,omitempty"`
+	Countdown       string `json:"Countdown,omitempty"`
+	Until           string `json:"Until,omitempty"`
+	Arrival         string `json:"Arrival,omitempty"`
+	BusinessArrival string `json:"BusinessArrival,omitempty"`
 }
 
 // LocationData represents the traveling and located members for a location

--- a/internal/domain/travel/travel_time_service_test.go
+++ b/internal/domain/travel/travel_time_service_test.go
@@ -159,6 +159,13 @@ func TestTravelTimeServiceCalculateTravelTimes(t *testing.T) {
 			travelType:       "business",
 			expectedDuration: 68 * time.Minute,
 		},
+		{
+			name:             "Switzerland standard travel (with business arrival)",
+			userID:           999,
+			destination:      "Switzerland",
+			travelType:       "standard",
+			expectedDuration: 175 * time.Minute, // Regular duration
+		},
 	}
 
 	for _, tt := range tests {
@@ -195,6 +202,28 @@ func TestTravelTimeServiceCalculateTravelTimes(t *testing.T) {
 			// Check countdown format
 			if result.Countdown == "" {
 				t.Error("Countdown should not be empty")
+			}
+
+			// For "standard" travel type, check BusinessArrival is calculated
+			if tt.travelType == "standard" {
+				if result.BusinessArrival == "" {
+					t.Error("BusinessArrival should not be empty for standard travel")
+				}
+
+				// Parse business arrival time and verify it's before regular arrival
+				businessArrival, err := time.Parse("2006-01-02 15:04:05", result.BusinessArrival)
+				if err != nil {
+					t.Fatalf("Failed to parse business arrival time: %v", err)
+				}
+
+				if !businessArrival.Before(arrivalTime) {
+					t.Error("Business arrival should be before regular arrival for standard travel")
+				}
+			} else {
+				// Non-standard travel should not have BusinessArrival
+				if result.BusinessArrival != "" {
+					t.Error("BusinessArrival should be empty for non-standard travel")
+				}
 			}
 		})
 	}

--- a/tactical_dashboard.html
+++ b/tactical_dashboard.html
@@ -244,6 +244,26 @@
             color: #000;
         }
 
+        .dual-arrival-container {
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+            align-items: flex-end;
+        }
+
+        .arrival-row {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .arrival-label {
+            font-size: 0.8em;
+            color: #666;
+            min-width: 60px;
+            text-align: right;
+        }
+
 
         .expand-icon {
             font-size: 0.8em;
@@ -456,7 +476,25 @@
 
             // Show calculated countdown for traveling members (from Arrival)
             if (member.Arrival) {
-                countdownHtml = `<div class="member-countdown" id="${arrivalCountdownId}" data-arrival-time="${member.Arrival}">Calculating...</div>`;
+                // If we have both arrival times, show both with labels
+                if (member.BusinessArrival && member.BusinessArrival !== member.Arrival) {
+                    const businessCountdownId = `business-countdown-${memberKey}`;
+                    countdownHtml = `
+                        <div class="dual-arrival-container">
+                            <div class="arrival-row">
+                                <span class="arrival-label">Regular:</span>
+                                <div class="member-countdown" id="${arrivalCountdownId}" data-arrival-time="${member.Arrival}">Calculating...</div>
+                            </div>
+                            <div class="arrival-row">
+                                <span class="arrival-label">Business:</span>
+                                <div class="member-countdown" id="${businessCountdownId}" data-arrival-time="${member.BusinessArrival}">Calculating...</div>
+                            </div>
+                        </div>
+                    `;
+                } else {
+                    // Single arrival time
+                    countdownHtml = `<div class="member-countdown" id="${arrivalCountdownId}" data-arrival-time="${member.Arrival}">Calculating...</div>`;
+                }
             }
             // Show calculated countdown for located members (from Until)
             else if (member.Until) {


### PR DESCRIPTION
## Summary
- Add comprehensive BusinessArrival field support across all data structures
- Implement business class travel time calculations for all 11 destinations (8-89 minutes)
- Add dual arrival time display in tactical dashboard for business class detection
- Update spreadsheet manager to properly handle BusinessArrival column
- Add JSON export support with BusinessArrival field for front-end consumption

## Key Features
- **Business Class Travel Times**: Complete mapping for all destinations (Mexico 8min, Switzerland 53min, etc.)
- **Dual Arrival Display**: Shows both regular and business arrival times in tactical dashboard
- **Smart Detection Logic**: BusinessArrival only calculated for "standard" travel type
- **Backward Compatibility**: Automatic detection of old vs new spreadsheet formats
- **JSON Export**: BusinessArrival included in travel data for front-end applications

## Technical Implementation
- Added BusinessArrival field to: TravelRecord, StatusV2Record, JSONMember, TravelTimeData
- Updated TravelTimeService with complete business class timing data  
- Enhanced tactical dashboard with conditional dual-arrival display
- Fixed spreadsheet writing logic to include BusinessArrival column
- Maintains existing manual adjustment preservation logic

## Test Cases Covered
- Property-based testing ensures business class is fastest travel option
- Edge case handling for unknown destinations and malformed data
- Comprehensive test coverage for all travel time calculations
- Backward compatibility testing for existing spreadsheet formats

## Business Value
Enables detection of potential business class travel by comparing actual arrival times against both regular and business class predictions, providing tactical intelligence for faction coordination.

🤖 Generated with [Claude Code](https://claude.ai/code)