### PR TITLE
Add member levels to tactical dashboard

### DIFF
--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -261,6 +261,7 @@ type StatusV2Record struct {
 type JSONMember struct {
 	Name            string `json:"Name"`
 	MemberID        string `json:"MemberID"`
+	Level           int    `json:"Level"`
 	State           string `json:"State"`
 	Status          string `json:"Status,omitempty"`
 	Countdown       string `json:"Countdown,omitempty"`

--- a/internal/application/services/status_v2_service.go
+++ b/internal/application/services/status_v2_service.go
@@ -562,6 +562,7 @@ func (s *StatusV2Service) createJSONMember(record app.StatusV2Record) app.JSONMe
 	member := app.JSONMember{
 		Name:     record.Name,
 		MemberID: record.MemberID,
+		Level:    record.Level,
 		State:    record.State,
 	}
 

--- a/internal/processing/mocks/torn_client.go
+++ b/internal/processing/mocks/torn_client.go
@@ -20,25 +20,25 @@ type TornClient interface {
 // MockTornClient is a test double for the torn.Client
 type MockTornClient struct {
 	// Responses to return
-	OwnFactionResponse          *app.FactionInfoResponse
-	FactionWarsResponse         *app.WarResponse
-	FactionAttacksResponse      *app.AttackResponse
-	FactionBasicResponse        *app.FactionBasicResponse
-	APICallCount                int64
+	OwnFactionResponse     *app.FactionInfoResponse
+	FactionWarsResponse    *app.WarResponse
+	FactionAttacksResponse *app.AttackResponse
+	FactionBasicResponse   *app.FactionBasicResponse
+	APICallCount           int64
 
 	// Errors to return
-	OwnFactionError          error
-	FactionWarsError         error
-	FactionAttacksError      error
-	FactionBasicError        error
+	OwnFactionError     error
+	FactionWarsError    error
+	FactionAttacksError error
+	FactionBasicError   error
 
 	// Call tracking
-	GetOwnFactionCalled              bool
-	GetFactionWarsCalled             bool
-	GetFactionAttacksCalled          bool
-	GetFactionBasicCalled            bool
-	GetFactionBasicCalledWithID      int
-	GetFactionAttacksCalledWith      struct {
+	GetOwnFactionCalled         bool
+	GetFactionWarsCalled        bool
+	GetFactionAttacksCalled     bool
+	GetFactionBasicCalled       bool
+	GetFactionBasicCalledWithID int
+	GetFactionAttacksCalledWith struct {
 		From int64
 		To   int64
 	}
@@ -65,8 +65,6 @@ func (m *MockTornClient) GetFactionAttacks(ctx context.Context, from, to int64) 
 	m.GetFactionAttacksCalledWith.To = to
 	return m.FactionAttacksResponse, m.FactionAttacksError
 }
-
-
 
 func (m *MockTornClient) GetFactionBasic(ctx context.Context, factionID int) (*app.FactionBasicResponse, error) {
 	m.GetFactionBasicCalled = true

--- a/internal/processing/wars_attack_test.go
+++ b/internal/processing/wars_attack_test.go
@@ -72,4 +72,3 @@ func TestProcessAttacksIntoRecords(t *testing.T) {
 		}
 	}
 }
-

--- a/internal/torn/client.go
+++ b/internal/torn/client.go
@@ -154,8 +154,6 @@ func (c *Client) GetFactionAttacks(ctx context.Context, from, to int64) (*app.At
 	return &attackResponse, nil
 }
 
-
-
 // GetFactionBasic fetches faction basic data from the API
 func (c *Client) GetFactionBasic(ctx context.Context, factionID int) (*app.FactionBasicResponse, error) {
 	url := fmt.Sprintf("https://api.torn.com/faction/%d?selections=basic&key=%s", factionID, c.apiKey)

--- a/tactical_dashboard.html
+++ b/tactical_dashboard.html
@@ -221,6 +221,19 @@
             margin-right: 15px;
         }
 
+        .member-level {
+            background: #e3f2fd;
+            color: #1976d2;
+            padding: 2px 6px;
+            border-radius: 10px;
+            font-size: 0.8em;
+            font-weight: 500;
+            margin-right: 8px;
+            min-width: 30px;
+            text-align: center;
+            border: 1px solid #bbdefb;
+        }
+
         .member-countdown {
             font-family: monospace;
             background: #f0f0f0;
@@ -501,10 +514,14 @@
                 countdownHtml = `<div class="member-countdown" id="${untilCountdownId}" data-until-time="${member.Until}">Calculating...</div>`;
             }
 
+            // Create level display if Level is available
+            const levelHtml = member.Level ? `<div class="member-level">Lv ${member.Level}</div>` : '';
+
             return `
                 <div class="member-row">
                     <div class="status-dot ${statusClass}"></div>
                     <div class="member-name">${memberNameHtml}</div>
+                    ${levelHtml}
                     ${statusText ? `<div class="member-status">${statusText}</div>` : ''}
                     ${countdownHtml}
                 </div>


### PR DESCRIPTION
## Summary

Adds member level display to the tactical intelligence dashboard with clean visual design.

## Changes Made

- **Level Display**: Added member levels as 'Lv X' badges next to member names
- **Styling**: Blue-themed badges with rounded corners and borders that complement the existing design
- **Layout**: Positioned levels between member names and status for optimal readability
- **Graceful Fallback**: Only displays level badges when Level data is available

## Visual Design

- Light blue background (#e3f2fd) with dark blue text (#1976d2)
- Small, compact badges that don't disrupt the existing layout
- Consistent spacing and typography with other dashboard elements

## Implementation Details

- Added  CSS class with responsive styling
- Updated  function to conditionally render level badges
- No breaking changes - works with existing data structure

The level badges provide quick tactical intelligence about member capabilities while maintaining the dashboard's clean, professional appearance.