### PR TITLE
feat: query BigQuery for previous member states instead of reading full sheet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,3 +250,7 @@ When making changes and preparing for release, follow this standardized process:
 - **Use descriptive commit messages** that explain the "why" not just the "what"
 - **Address reviewer feedback promptly** and work collaboratively
 - **Clean up branches** after successful merge to keep repository organized
+
+## Known Issues / Future Work
+
+- **Evaluate memory usage after BigQuery migration** — The "Changed States" sheet had ~154k rows and was previously read entirely into memory on every run. PR #67 added BigQuery as a dual-write sink, and a follow-up change replaced the full sheet scan with a targeted BQ query (one row per member). Memory usage should be significantly lower now, but this has not been measured in production. Profile the running service to confirm the improvement.

--- a/internal/application/services/state_tracking_service.go
+++ b/internal/application/services/state_tracking_service.go
@@ -73,15 +73,31 @@ func (s *StateTrackingService) ProcessStateChanges(ctx context.Context, spreadsh
 		return fmt.Errorf("failed to ensure Changed States sheet: %w", err)
 	}
 
-	// Step 3: Read existing records from Changed States sheet
-	allPreviousStates, err := s.readChangedStatesSheet(ctx, spreadsheetID)
-	if err != nil {
-		return fmt.Errorf("failed to read Changed States sheet: %w", err)
+	// Step 3: Read previous states — prefer BigQuery (one row per member) over full sheet scan
+	var allPreviousStates []app.StateRecord
+	if s.bigqueryClient != nil {
+		memberIDs := make([]string, 0, len(currentStateRecords))
+		for _, r := range currentStateRecords {
+			memberIDs = append(memberIDs, r.MemberID)
+		}
+		allPreviousStates, err = s.bigqueryClient.QueryLatestStatePerMember(ctx, memberIDs)
+		if err != nil {
+			log.Warn().Err(err).Msg("BigQuery previous-state query failed, falling back to sheet read")
+			allPreviousStates, err = s.readChangedStatesSheet(ctx, spreadsheetID)
+			if err != nil {
+				return fmt.Errorf("failed to read Changed States sheet: %w", err)
+			}
+		}
+	} else {
+		allPreviousStates, err = s.readChangedStatesSheet(ctx, spreadsheetID)
+		if err != nil {
+			return fmt.Errorf("failed to read Changed States sheet: %w", err)
+		}
 	}
 
 	log.Debug().
 		Int("previous_records", len(allPreviousStates)).
-		Msg("Read previous state records from sheet")
+		Msg("Read previous state records")
 
 	// Step 4: Create previous state collection for comparison
 	previousStateRecords := s.comparator.CreatePreviousStateCollection(currentStateRecords, allPreviousStates)

--- a/internal/application/services/state_tracking_service_test.go
+++ b/internal/application/services/state_tracking_service_test.go
@@ -96,12 +96,13 @@ func TestStateTrackingService_BigQueryNotCalledWhenNoChanges(t *testing.T) {
 
 	sheetsMock := mocks.NewMockSheetsClient()
 	sheetsMock.SheetExistsResponse = true
-	// Return a previous record for the same member with the same state → no change
-	sheetsMock.ReadSheetResponse = [][]interface{}{
-		{"2026-01-01 00:00:00", "42", "Player1", "100", "TestFaction", "Online", "Okay", "okay", "", ""},
-	}
 
 	bqMock := mocks.NewMockBigQueryClient()
+	// Return a previous record for the same member with the same state → no change
+	bqMock.QueryLatestStatePerMemberResponse = []app.StateRecord{
+		{MemberID: "42", MemberName: "Player1", FactionID: "100", FactionName: "TestFaction",
+			LastActionStatus: "Online", StatusDescription: "Okay", StatusState: "okay"},
+	}
 
 	svc := NewStateTrackingServiceWithBigQuery(tornMock, sheetsMock, bqMock)
 	if err := svc.ProcessStateChanges(ctx, "spreadsheet-id", []int{100}); err != nil {

--- a/internal/bigquery/client.go
+++ b/internal/bigquery/client.go
@@ -7,14 +7,17 @@ import (
 
 	bq "cloud.google.com/go/bigquery"
 	"github.com/rs/zerolog/log"
+	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 
 	"torn_rw_stats/internal/app"
 )
 
-// Client wraps the BigQuery streaming insert API for state record insertion.
+// Client wraps the BigQuery streaming insert and query APIs for state records.
 type Client struct {
+	bqClient  *bq.Client
 	inserter  *bq.Inserter
+	projectID string
 	datasetID string
 	tableID   string
 }
@@ -29,7 +32,9 @@ func NewClient(ctx context.Context, credentialsFile, projectID, datasetID, table
 	inserter := bqClient.Dataset(datasetID).Table(tableID).Inserter()
 
 	return &Client{
+		bqClient:  bqClient,
 		inserter:  inserter,
+		projectID: projectID,
 		datasetID: datasetID,
 		tableID:   tableID,
 	}, nil
@@ -59,6 +64,85 @@ func (r *stateRecordRow) Save() (map[string]bq.Value, string, error) {
 	}
 	// Empty InsertID: BigQuery assigns its own dedup ID (at-least-once semantics).
 	return row, "", nil
+}
+
+// QueryLatestStatePerMember returns the most recent StateRecord for each of the
+// given member IDs. Members with no history are omitted from the result.
+func (c *Client) QueryLatestStatePerMember(ctx context.Context, memberIDs []string) ([]app.StateRecord, error) {
+	if len(memberIDs) == 0 {
+		return nil, nil
+	}
+
+	sql := fmt.Sprintf(`
+SELECT member_id, member_name, faction_id, faction_name,
+       last_action_status, status_description, status_state,
+       status_until, status_travel_type, timestamp
+FROM (
+  SELECT *,
+    ROW_NUMBER() OVER (PARTITION BY member_id ORDER BY timestamp DESC) AS rn
+  FROM %s.%s.%s
+  WHERE member_id IN UNNEST(@member_ids)
+)
+WHERE rn = 1`,
+		c.projectID, c.datasetID, c.tableID)
+
+	q := c.bqClient.Query(sql)
+	q.Parameters = []bq.QueryParameter{
+		{Name: "member_ids", Value: memberIDs},
+	}
+
+	start := time.Now()
+	it, err := q.Read(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("bigquery query failed: %w", err)
+	}
+
+	var records []app.StateRecord
+	for {
+		var row struct {
+			MemberID          string           `bigquery:"member_id"`
+			MemberName        string           `bigquery:"member_name"`
+			FactionID         string           `bigquery:"faction_id"`
+			FactionName       string           `bigquery:"faction_name"`
+			LastActionStatus  string           `bigquery:"last_action_status"`
+			StatusDescription string           `bigquery:"status_description"`
+			StatusState       string           `bigquery:"status_state"`
+			StatusUntil       bq.NullTimestamp `bigquery:"status_until"`
+			StatusTravelType  string           `bigquery:"status_travel_type"`
+			Timestamp         time.Time        `bigquery:"timestamp"`
+		}
+		err := it.Next(&row)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("bigquery row iteration failed: %w", err)
+		}
+
+		r := app.StateRecord{
+			Timestamp:         row.Timestamp.UTC(),
+			MemberID:          row.MemberID,
+			MemberName:        row.MemberName,
+			FactionID:         row.FactionID,
+			FactionName:       row.FactionName,
+			LastActionStatus:  row.LastActionStatus,
+			StatusDescription: row.StatusDescription,
+			StatusState:       row.StatusState,
+			StatusTravelType:  row.StatusTravelType,
+		}
+		if row.StatusUntil.Valid {
+			r.StatusUntil = row.StatusUntil.Timestamp.UTC()
+		}
+		records = append(records, r)
+	}
+
+	log.Debug().
+		Int("members_queried", len(memberIDs)).
+		Int("records_returned", len(records)).
+		Dur("duration", time.Since(start)).
+		Msg("BigQuery latest-state-per-member query complete")
+
+	return records, nil
 }
 
 // InsertStateRecords streams the provided records into BigQuery.

--- a/internal/processing/interfaces.go
+++ b/internal/processing/interfaces.go
@@ -72,7 +72,8 @@ type WarStateManagerInterface interface {
 	GetCurrentWar() *app.War
 }
 
-// BigQueryClientInterface defines the BigQuery client methods used for state record insertion
+// BigQueryClientInterface defines the BigQuery client methods used for state record insertion and querying
 type BigQueryClientInterface interface {
 	InsertStateRecords(ctx context.Context, records []app.StateRecord) error
+	QueryLatestStatePerMember(ctx context.Context, memberIDs []string) ([]app.StateRecord, error)
 }

--- a/internal/processing/mocks/bigquery_client.go
+++ b/internal/processing/mocks/bigquery_client.go
@@ -8,12 +8,18 @@ import (
 
 // MockBigQueryClient is a test double for bigquery.Client
 type MockBigQueryClient struct {
-	// Error to return
-	InsertStateRecordsError error
+	// Errors to return
+	InsertStateRecordsError        error
+	QueryLatestStatePerMemberError error
+
+	// Responses to return
+	QueryLatestStatePerMemberResponse []app.StateRecord
 
 	// Call tracking
-	InsertStateRecordsCalled     bool
-	InsertStateRecordsCalledWith []app.StateRecord
+	InsertStateRecordsCalled            bool
+	InsertStateRecordsCalledWith        []app.StateRecord
+	QueryLatestStatePerMemberCalled     bool
+	QueryLatestStatePerMemberCalledWith []string
 }
 
 // NewMockBigQueryClient creates a new mock BigQuery client
@@ -27,9 +33,19 @@ func (m *MockBigQueryClient) InsertStateRecords(_ context.Context, records []app
 	return m.InsertStateRecordsError
 }
 
+func (m *MockBigQueryClient) QueryLatestStatePerMember(_ context.Context, memberIDs []string) ([]app.StateRecord, error) {
+	m.QueryLatestStatePerMemberCalled = true
+	m.QueryLatestStatePerMemberCalledWith = memberIDs
+	return m.QueryLatestStatePerMemberResponse, m.QueryLatestStatePerMemberError
+}
+
 // Reset clears all call tracking and errors
 func (m *MockBigQueryClient) Reset() {
 	m.InsertStateRecordsError = nil
 	m.InsertStateRecordsCalled = false
 	m.InsertStateRecordsCalledWith = nil
+	m.QueryLatestStatePerMemberError = nil
+	m.QueryLatestStatePerMemberResponse = nil
+	m.QueryLatestStatePerMemberCalled = false
+	m.QueryLatestStatePerMemberCalledWith = nil
 }


### PR DESCRIPTION
## Summary
- Replaces the full \"Changed States\" sheet read (~154k rows read into memory every run) with a targeted BigQuery query
- New `QueryLatestStatePerMember` method on the BQ client uses `ROW_NUMBER() OVER (PARTITION BY member_id ORDER BY timestamp DESC)` to return exactly one row per tracked member
- Falls back to the sheet read if the BQ query fails (non-fatal degradation)
- Adds the new method to `BigQueryClientInterface` and the mock

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean
- [x] Updated `TestStateTrackingService_BigQueryNotCalledWhenNoChanges` to wire previous state via BQ mock instead of sheets mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)