### PR TITLE
feat: replace 154k-row sheet reads in Status v2 path with targeted BQ queries

### DIFF
--- a/internal/application/services/optimized_war_processor.go
+++ b/internal/application/services/optimized_war_processor.go
@@ -45,7 +45,7 @@ func NewOptimizedWarProcessor(
 	stateTracker := NewStateTrackingServiceWithBigQuery(tornClient, sheetsClient, bqClient)
 
 	// Create Status v2 processor
-	statusV2Processor := NewStatusV2Processor(tornClient, sheetsClient, config.DeployURL)
+	statusV2Processor := NewStatusV2Processor(tornClient, sheetsClient, bqClient, config.DeployURL)
 
 	// Create processor with raw client
 	processor := NewWarProcessor(

--- a/internal/application/services/status_v2_departure.go
+++ b/internal/application/services/status_v2_departure.go
@@ -8,29 +8,51 @@ import (
 	"torn_rw_stats/internal/app"
 	"torn_rw_stats/internal/domain/state"
 	"torn_rw_stats/internal/domain/travel"
+
+	"github.com/rs/zerolog/log"
 )
 
-// buildDepartureMap builds a map of member departure times from state changes
+// buildDepartureMap builds a map of member departure times from state changes.
+// Uses BigQuery when available; falls back to a full sheet scan.
 func (s *StatusV2Service) buildDepartureMap(ctx context.Context, spreadsheetID string, currentStateRecords []app.StateRecord) (map[string]time.Time, error) {
 	departureMap := make(map[string]time.Time)
 
-	// Read all state records from Changed States sheet
+	// Collect IDs of currently-traveling members only
+	var travelingIDs []string
+	travelingRecords := make(map[string]app.StateRecord)
+	for _, r := range currentStateRecords {
+		if r.StatusState == "Traveling" {
+			travelingIDs = append(travelingIDs, r.MemberID)
+			travelingRecords[r.MemberID] = r
+		}
+	}
+	if len(travelingIDs) == 0 {
+		return departureMap, nil
+	}
+
+	if s.bigqueryClient != nil {
+		times, err := s.bigqueryClient.QueryDepartureTimes(ctx, travelingIDs)
+		if err != nil {
+			log.Warn().Err(err).Msg("BigQuery departure query failed, falling back to sheet scan")
+		} else {
+			for memberID, t := range times {
+				r := travelingRecords[memberID]
+				memberKey := fmt.Sprintf("%s_%s", r.FactionID, memberID)
+				departureMap[memberKey] = t
+			}
+			return departureMap, nil
+		}
+	}
+
+	// Fall back: full sheet scan
 	allStateRecords, err := s.ReadAllStateRecords(ctx, spreadsheetID)
 	if err != nil {
 		return departureMap, fmt.Errorf("failed to read state records: %w", err)
 	}
-
-	// For each current traveling member, find their most recent transition to traveling
-	for _, currentRecord := range currentStateRecords {
-		if currentRecord.StatusState != "Traveling" {
-			continue
-		}
-
-		memberKey := fmt.Sprintf("%s_%s", currentRecord.FactionID, currentRecord.MemberID)
-		// Parse the current destination location instead of using raw status description
+	for memberID, currentRecord := range travelingRecords {
+		memberKey := fmt.Sprintf("%s_%s", currentRecord.FactionID, memberID)
 		currentParsedLocation := s.locationService.ParseLocation(currentRecord.StatusDescription)
-		departureTime := s.findMostRecentTravelingTransition(allStateRecords, currentRecord.MemberID, currentParsedLocation)
-
+		departureTime := s.findMostRecentTravelingTransition(allStateRecords, memberID, currentParsedLocation)
 		if !departureTime.IsZero() {
 			departureMap[memberKey] = departureTime
 		}

--- a/internal/application/services/status_v2_processor.go
+++ b/internal/application/services/status_v2_processor.go
@@ -25,16 +25,23 @@ type StatusV2Processor struct {
 }
 
 // NewStatusV2Processor creates a new Status v2 processor
-func NewStatusV2Processor(tornClient processing.TornClientInterface, sheetsClient processing.SheetsClientInterface, deployURL string) *StatusV2Processor {
+func NewStatusV2Processor(tornClient processing.TornClientInterface, sheetsClient processing.SheetsClientInterface, bqClient processing.BigQueryClientInterface, deployURL string) *StatusV2Processor {
 	var deployer *deployment.SSHDeployer
 	if deployURL != "" {
 		deployer = deployment.NewSSHDeployer(deployURL)
 	}
 
+	var svc *StatusV2Service
+	if bqClient != nil {
+		svc = NewStatusV2ServiceWithBigQuery(sheetsClient, bqClient)
+	} else {
+		svc = NewStatusV2Service(sheetsClient)
+	}
+
 	return &StatusV2Processor{
 		tornClient:   tornClient,
 		sheetsClient: sheetsClient,
-		service:      NewStatusV2Service(sheetsClient),
+		service:      svc,
 		ourFactionID: 0, // will be fetched via API when needed
 		deployer:     deployer,
 	}
@@ -103,8 +110,9 @@ func (p *StatusV2Processor) ProcessStatusV2ForFaction(ctx context.Context, sprea
 		return fmt.Errorf("failed to get faction data: %w", err)
 	}
 
-	// Step 3: Read all state records from Changed States sheet to get current state
-	allStateRecords, err := p.service.ReadAllStateRecords(ctx, spreadsheetID)
+	// Step 3: Get current state records for this faction — prefer BigQuery over full sheet scan
+	factionIDStr := fmt.Sprintf("%d", factionID)
+	currentStateRecords, err := p.service.readCurrentStateRecords(ctx, spreadsheetID, factionIDStr)
 	if err != nil {
 		log.Error().
 			Err(err).
@@ -112,14 +120,6 @@ func (p *StatusV2Processor) ProcessStatusV2ForFaction(ctx context.Context, sprea
 			Msg("Failed to read state records")
 		return fmt.Errorf("failed to read state records: %w", err)
 	}
-
-	log.Info().
-		Int("faction_id", factionID).
-		Int("total_state_records", len(allStateRecords)).
-		Msg("Successfully read all state records")
-
-	// Step 4: Find current state records for this faction
-	currentStateRecords := p.filterStateRecordsForFaction(allStateRecords, factionID)
 
 	log.Info().
 		Int("faction_id", factionID).
@@ -185,69 +185,6 @@ func (p *StatusV2Processor) ProcessStatusV2ForFaction(ctx context.Context, sprea
 	}
 
 	return nil
-}
-
-// filterStateRecordsForFaction filters state records to only include current records for the specified faction
-func (p *StatusV2Processor) filterStateRecordsForFaction(allStateRecords []app.StateRecord, factionID int) []app.StateRecord {
-	factionIDStr := fmt.Sprintf("%d", factionID)
-
-	log.Debug().
-		Int("faction_id", factionID).
-		Str("faction_id_str", factionIDStr).
-		Int("total_records_to_filter", len(allStateRecords)).
-		Msg("Starting faction filtering")
-
-	// Group by member ID and find the most recent record for each member
-	memberLatest := make(map[string]app.StateRecord)
-	matchingRecords := 0
-
-	// Debug: Show what we're actually reading from each column
-	if len(allStateRecords) > 0 {
-		firstRecord := allStateRecords[0]
-		log.Info().
-			Str("member_id", firstRecord.MemberID).
-			Str("member_name", firstRecord.MemberName).
-			Str("faction_id", firstRecord.FactionID).
-			Str("faction_name", firstRecord.FactionName).
-			Str("last_action_status", firstRecord.LastActionStatus).
-			Str("status_description", firstRecord.StatusDescription).
-			Str("status_state", firstRecord.StatusState).
-			Str("status_travel_type", firstRecord.StatusTravelType).
-			Msg("DEBUG: First record parsed values")
-	}
-
-	for _, record := range allStateRecords {
-		if record.FactionID != factionIDStr {
-			continue
-		}
-		matchingRecords++
-
-		existing, exists := memberLatest[record.MemberID]
-		if !exists || record.Timestamp.After(existing.Timestamp) {
-			memberLatest[record.MemberID] = record
-		}
-	}
-
-	log.Info().
-		Int("faction_id", factionID).
-		Str("faction_id_str", factionIDStr).
-		Int("total_records_checked", len(allStateRecords)).
-		Int("matching_faction_records", matchingRecords).
-		Int("unique_members", len(memberLatest)).
-		Msg("Faction filtering progress")
-
-	// Convert map back to slice
-	var currentRecords []app.StateRecord
-	for _, record := range memberLatest {
-		currentRecords = append(currentRecords, record)
-	}
-
-	log.Debug().
-		Int("faction_id", factionID).
-		Int("final_current_records", len(currentRecords)).
-		Msg("Completed faction filtering")
-
-	return currentRecords
 }
 
 // exportAndDeployJSON converts StatusV2Records to JSON format and deploys it

--- a/internal/application/services/status_v2_service.go
+++ b/internal/application/services/status_v2_service.go
@@ -16,6 +16,7 @@ import (
 // tracking departure times for traveling players and calculating arrival predictions.
 type StatusV2Service struct {
 	sheetsClient      processing.SheetsClientInterface
+	bigqueryClient    processing.BigQueryClientInterface // nil = disabled
 	locationService   *travel.LocationService
 	travelTimeService *travel.TravelTimeService
 }
@@ -24,6 +25,16 @@ type StatusV2Service struct {
 func NewStatusV2Service(sheetsClient processing.SheetsClientInterface) *StatusV2Service {
 	return &StatusV2Service{
 		sheetsClient:      sheetsClient,
+		locationService:   travel.NewLocationService(),
+		travelTimeService: travel.NewTravelTimeService(),
+	}
+}
+
+// NewStatusV2ServiceWithBigQuery creates a Status v2 service that uses BigQuery for history lookups.
+func NewStatusV2ServiceWithBigQuery(sheetsClient processing.SheetsClientInterface, bqClient processing.BigQueryClientInterface) *StatusV2Service {
+	return &StatusV2Service{
+		sheetsClient:      sheetsClient,
+		bigqueryClient:    bqClient,
 		locationService:   travel.NewLocationService(),
 		travelTimeService: travel.NewTravelTimeService(),
 	}

--- a/internal/application/services/status_v2_storage.go
+++ b/internal/application/services/status_v2_storage.go
@@ -76,6 +76,39 @@ func (s *StatusV2Service) getExistingStatusV2Data(ctx context.Context, spreadshe
 	return data, nil
 }
 
+// readCurrentStateRecords returns the latest state record per member for a faction.
+// Uses BigQuery when available; falls back to a full sheet scan.
+func (s *StatusV2Service) readCurrentStateRecords(ctx context.Context, spreadsheetID, factionID string) ([]app.StateRecord, error) {
+	if s.bigqueryClient != nil {
+		records, err := s.bigqueryClient.QueryLatestStatePerFaction(ctx, factionID)
+		if err != nil {
+			log.Warn().Err(err).Str("faction_id", factionID).Msg("BigQuery faction query failed, falling back to sheet scan")
+		} else {
+			return records, nil
+		}
+	}
+
+	// Fall back: full sheet scan + in-process filter
+	all, err := s.ReadAllStateRecords(ctx, spreadsheetID)
+	if err != nil {
+		return nil, err
+	}
+	memberLatest := make(map[string]app.StateRecord)
+	for _, r := range all {
+		if r.FactionID != factionID {
+			continue
+		}
+		if existing, ok := memberLatest[r.MemberID]; !ok || r.Timestamp.After(existing.Timestamp) {
+			memberLatest[r.MemberID] = r
+		}
+	}
+	result := make([]app.StateRecord, 0, len(memberLatest))
+	for _, r := range memberLatest {
+		result = append(result, r)
+	}
+	return result, nil
+}
+
 // ReadAllStateRecords reads all state records from the Changed States sheet
 func (s *StatusV2Service) ReadAllStateRecords(ctx context.Context, spreadsheetID string) ([]app.StateRecord, error) {
 	sheetName := "Changed States"

--- a/internal/bigquery/client.go
+++ b/internal/bigquery/client.go
@@ -145,6 +145,140 @@ WHERE rn = 1`,
 	return records, nil
 }
 
+// QueryLatestStatePerFaction returns the most recent StateRecord for each member
+// of the given faction. Members with no history are omitted from the result.
+func (c *Client) QueryLatestStatePerFaction(ctx context.Context, factionID string) ([]app.StateRecord, error) {
+	sql := fmt.Sprintf(`
+SELECT member_id, member_name, faction_id, faction_name,
+       last_action_status, status_description, status_state,
+       status_until, status_travel_type, timestamp
+FROM (
+  SELECT *,
+    ROW_NUMBER() OVER (PARTITION BY member_id ORDER BY timestamp DESC) AS rn
+  FROM %s.%s.%s
+  WHERE faction_id = @faction_id
+)
+WHERE rn = 1`,
+		c.projectID, c.datasetID, c.tableID)
+
+	q := c.bqClient.Query(sql)
+	q.Parameters = []bq.QueryParameter{
+		{Name: "faction_id", Value: factionID},
+	}
+
+	start := time.Now()
+	it, err := q.Read(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("bigquery faction query failed: %w", err)
+	}
+
+	var records []app.StateRecord
+	for {
+		var row struct {
+			MemberID          string           `bigquery:"member_id"`
+			MemberName        string           `bigquery:"member_name"`
+			FactionID         string           `bigquery:"faction_id"`
+			FactionName       string           `bigquery:"faction_name"`
+			LastActionStatus  string           `bigquery:"last_action_status"`
+			StatusDescription string           `bigquery:"status_description"`
+			StatusState       string           `bigquery:"status_state"`
+			StatusUntil       bq.NullTimestamp `bigquery:"status_until"`
+			StatusTravelType  string           `bigquery:"status_travel_type"`
+			Timestamp         time.Time        `bigquery:"timestamp"`
+		}
+		err := it.Next(&row)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("bigquery row iteration failed: %w", err)
+		}
+
+		r := app.StateRecord{
+			Timestamp:         row.Timestamp.UTC(),
+			MemberID:          row.MemberID,
+			MemberName:        row.MemberName,
+			FactionID:         row.FactionID,
+			FactionName:       row.FactionName,
+			LastActionStatus:  row.LastActionStatus,
+			StatusDescription: row.StatusDescription,
+			StatusState:       row.StatusState,
+			StatusTravelType:  row.StatusTravelType,
+		}
+		if row.StatusUntil.Valid {
+			r.StatusUntil = row.StatusUntil.Timestamp.UTC()
+		}
+		records = append(records, r)
+	}
+
+	log.Debug().
+		Str("faction_id", factionID).
+		Int("records_returned", len(records)).
+		Dur("duration", time.Since(start)).
+		Msg("BigQuery latest-state-per-faction query complete")
+
+	return records, nil
+}
+
+// QueryDepartureTimes returns the most recent transition-to-traveling timestamp for
+// each of the given member IDs. Members with no traveling history are omitted.
+func (c *Client) QueryDepartureTimes(ctx context.Context, memberIDs []string) (map[string]time.Time, error) {
+	if len(memberIDs) == 0 {
+		return nil, nil
+	}
+
+	sql := fmt.Sprintf(`
+SELECT member_id, timestamp AS departure_time
+FROM (
+  SELECT
+    member_id,
+    timestamp,
+    status_state,
+    LAG(status_state) OVER (PARTITION BY member_id ORDER BY timestamp) AS prev_status_state
+  FROM %s.%s.%s
+  WHERE member_id IN UNNEST(@member_ids)
+)
+WHERE status_state = 'Traveling'
+  AND (prev_status_state IS NULL OR prev_status_state != 'Traveling')
+QUALIFY ROW_NUMBER() OVER (PARTITION BY member_id ORDER BY timestamp DESC) = 1`,
+		c.projectID, c.datasetID, c.tableID)
+
+	q := c.bqClient.Query(sql)
+	q.Parameters = []bq.QueryParameter{
+		{Name: "member_ids", Value: memberIDs},
+	}
+
+	start := time.Now()
+	it, err := q.Read(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("bigquery departure query failed: %w", err)
+	}
+
+	result := make(map[string]time.Time)
+	for {
+		var row struct {
+			MemberID      string    `bigquery:"member_id"`
+			DepartureTime time.Time `bigquery:"departure_time"`
+		}
+		err := it.Next(&row)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("bigquery row iteration failed: %w", err)
+		}
+		result[row.MemberID] = row.DepartureTime.UTC()
+	}
+
+	log.Debug().
+		Int("members_queried", len(memberIDs)).
+		Int("departures_found", len(result)).
+		Dur("duration", time.Since(start)).
+		Msg("BigQuery departure-times query complete")
+
+	return result, nil
+}
+
 // InsertStateRecords streams the provided records into BigQuery.
 func (c *Client) InsertStateRecords(ctx context.Context, records []app.StateRecord) error {
 	if len(records) == 0 {

--- a/internal/processing/interfaces.go
+++ b/internal/processing/interfaces.go
@@ -76,4 +76,6 @@ type WarStateManagerInterface interface {
 type BigQueryClientInterface interface {
 	InsertStateRecords(ctx context.Context, records []app.StateRecord) error
 	QueryLatestStatePerMember(ctx context.Context, memberIDs []string) ([]app.StateRecord, error)
+	QueryLatestStatePerFaction(ctx context.Context, factionID string) ([]app.StateRecord, error)
+	QueryDepartureTimes(ctx context.Context, memberIDs []string) (map[string]time.Time, error)
 }

--- a/internal/processing/mocks/bigquery_client.go
+++ b/internal/processing/mocks/bigquery_client.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"context"
+	"time"
 
 	"torn_rw_stats/internal/app"
 )
@@ -9,17 +10,25 @@ import (
 // MockBigQueryClient is a test double for bigquery.Client
 type MockBigQueryClient struct {
 	// Errors to return
-	InsertStateRecordsError        error
-	QueryLatestStatePerMemberError error
+	InsertStateRecordsError         error
+	QueryLatestStatePerMemberError  error
+	QueryLatestStatePerFactionError error
+	QueryDepartureTimesError        error
 
 	// Responses to return
-	QueryLatestStatePerMemberResponse []app.StateRecord
+	QueryLatestStatePerMemberResponse  []app.StateRecord
+	QueryLatestStatePerFactionResponse []app.StateRecord
+	QueryDepartureTimesResponse        map[string]time.Time
 
 	// Call tracking
-	InsertStateRecordsCalled            bool
-	InsertStateRecordsCalledWith        []app.StateRecord
-	QueryLatestStatePerMemberCalled     bool
-	QueryLatestStatePerMemberCalledWith []string
+	InsertStateRecordsCalled             bool
+	InsertStateRecordsCalledWith         []app.StateRecord
+	QueryLatestStatePerMemberCalled      bool
+	QueryLatestStatePerMemberCalledWith  []string
+	QueryLatestStatePerFactionCalled     bool
+	QueryLatestStatePerFactionCalledWith string
+	QueryDepartureTimesCalled            bool
+	QueryDepartureTimesCalledWith        []string
 }
 
 // NewMockBigQueryClient creates a new mock BigQuery client
@@ -39,6 +48,18 @@ func (m *MockBigQueryClient) QueryLatestStatePerMember(_ context.Context, member
 	return m.QueryLatestStatePerMemberResponse, m.QueryLatestStatePerMemberError
 }
 
+func (m *MockBigQueryClient) QueryLatestStatePerFaction(_ context.Context, factionID string) ([]app.StateRecord, error) {
+	m.QueryLatestStatePerFactionCalled = true
+	m.QueryLatestStatePerFactionCalledWith = factionID
+	return m.QueryLatestStatePerFactionResponse, m.QueryLatestStatePerFactionError
+}
+
+func (m *MockBigQueryClient) QueryDepartureTimes(_ context.Context, memberIDs []string) (map[string]time.Time, error) {
+	m.QueryDepartureTimesCalled = true
+	m.QueryDepartureTimesCalledWith = memberIDs
+	return m.QueryDepartureTimesResponse, m.QueryDepartureTimesError
+}
+
 // Reset clears all call tracking and errors
 func (m *MockBigQueryClient) Reset() {
 	m.InsertStateRecordsError = nil
@@ -48,4 +69,12 @@ func (m *MockBigQueryClient) Reset() {
 	m.QueryLatestStatePerMemberResponse = nil
 	m.QueryLatestStatePerMemberCalled = false
 	m.QueryLatestStatePerMemberCalledWith = nil
+	m.QueryLatestStatePerFactionError = nil
+	m.QueryLatestStatePerFactionResponse = nil
+	m.QueryLatestStatePerFactionCalled = false
+	m.QueryLatestStatePerFactionCalledWith = ""
+	m.QueryDepartureTimesError = nil
+	m.QueryDepartureTimesResponse = nil
+	m.QueryDepartureTimesCalled = false
+	m.QueryDepartureTimesCalledWith = nil
 }


### PR DESCRIPTION
## Summary
- Status v2 processor was reading all 154k rows from the Changed States sheet **twice** per cycle
- First read: find each faction member's latest state (→ replaced with `QueryLatestStatePerFaction`)
- Second read: find departure times for currently-traveling members (→ replaced with `QueryDepartureTimes`)
- Both new BQ queries return only the rows actually needed rather than the full table
- Both fall back to the full sheet scan if BigQuery errors
- Removed dead `filterStateRecordsForFaction` method

## New BQ queries
- `QueryLatestStatePerFaction`: `ROW_NUMBER() OVER (PARTITION BY member_id ORDER BY timestamp DESC)` filtered to `faction_id = @faction_id`
- `QueryDepartureTimes`: `LAG(status_state)` to detect the most recent non-Traveling → Traveling transition per member

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)