### PR TITLE
ops: reduce memory request to 32Mi and limit to 64Mi

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -31,10 +31,10 @@ spec:
           # Resource limits based on Go application profile
           resources:
             requests:
-              memory: "128Mi"
+              memory: "32Mi"
               cpu: "100m"
             limits:
-              memory: "256Mi"
+              memory: "64Mi"
               cpu: "200m"
 
           # Environment variables from ConfigMap


### PR DESCRIPTION
## Summary
- Production RSS settled at 8Mi after replacing 154k-row sheet reads with targeted BQ queries (PRs #69, #70)
- Previous 128Mi request / 256Mi limit were ~16x over-provisioned
- New values: 32Mi request (4x headroom) / 64Mi limit (8x headroom)

## Test plan
- [x] `kubectl top pod` confirmed 8Mi RSS before this change
- [ ] Verify pod stays healthy after rollout with new limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)