### PR TITLE
feat: drop Changed States Google Sheet as write target

### DIFF
--- a/internal/application/services/departure_fix_test.go
+++ b/internal/application/services/departure_fix_test.go
@@ -2,89 +2,9 @@ package services
 
 import (
 	"testing"
-	"time"
 
-	"torn_rw_stats/internal/app"
 	"torn_rw_stats/internal/domain/travel"
 )
-
-func TestDepartureTimeDetectionWithParsedLocations(t *testing.T) {
-	// Setup
-	locationService := travel.NewLocationService()
-	service := &StatusV2Service{
-		locationService: locationService,
-	}
-
-	// King_Taurus scenario: travels to Switzerland, then returns to Torn
-	memberID := "3330609"
-
-	// Create state records representing King_Taurus's journey
-	baseTime := time.Date(2025, 9, 18, 0, 13, 8, 0, time.UTC)
-
-	allRecords := []app.StateRecord{
-		// Initial departure to Switzerland at 0:13:08
-		{
-			Timestamp:         baseTime,
-			MemberID:          memberID,
-			StatusState:       "Traveling",
-			StatusDescription: "Traveling to Switzerland",
-		},
-		// Multiple intermediate records (status changes while traveling)
-		{
-			Timestamp:         baseTime.Add(1 * time.Minute),
-			MemberID:          memberID,
-			StatusState:       "Traveling",
-			StatusDescription: "Traveling to Switzerland",
-		},
-		// Direction change at 2:17:06 - starts returning
-		{
-			Timestamp:         baseTime.Add(2*time.Hour + 4*time.Minute + 6*time.Second),
-			MemberID:          memberID,
-			StatusState:       "Traveling",
-			StatusDescription: "Returning to Torn from Switzerland",
-		},
-		// Continuing return journey
-		{
-			Timestamp:         baseTime.Add(2*time.Hour + 10*time.Minute),
-			MemberID:          memberID,
-			StatusState:       "Traveling",
-			StatusDescription: "Returning to Torn from Switzerland",
-		},
-	}
-
-	tests := []struct {
-		name               string
-		currentDestination string
-		expectedDeparture  time.Time
-		description        string
-	}{
-		{
-			name:               "Find departure for Switzerland trip",
-			currentDestination: "Switzerland",
-			expectedDeparture:  baseTime, // Should find initial departure at 0:13:08
-			description:        "Should find when King_Taurus first started traveling to Switzerland",
-		},
-		{
-			name:               "Find departure for return to Torn",
-			currentDestination: "Torn",
-			expectedDeparture:  baseTime.Add(2*time.Hour + 4*time.Minute + 6*time.Second), // Should find return departure at 2:17:06
-			description:        "Should find when King_Taurus started returning to Torn",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := service.findMostRecentTravelingTransition(allRecords, memberID, tt.currentDestination)
-
-			if !result.Equal(tt.expectedDeparture) {
-				t.Errorf("findMostRecentTravelingTransition() = %v, expected %v",
-					result.Format("2006-01-02 15:04:05"),
-					tt.expectedDeparture.Format("2006-01-02 15:04:05"))
-				t.Errorf("Description: %s", tt.description)
-			}
-		})
-	}
-}
 
 func TestLocationParsingConsistency(t *testing.T) {
 	locationService := travel.NewLocationService()

--- a/internal/application/services/optimized_war_processor.go
+++ b/internal/application/services/optimized_war_processor.go
@@ -41,8 +41,8 @@ func NewOptimizedWarProcessor(
 	tracker := NewAPICallTracker()
 	stateManager := war.NewWarStateManager()
 
-	// Create state tracking service with optional BigQuery sink
-	stateTracker := NewStateTrackingServiceWithBigQuery(tornClient, sheetsClient, bqClient)
+	// Create state tracking service
+	stateTracker := NewStateTrackingService(tornClient, bqClient)
 
 	// Create Status v2 processor
 	statusV2Processor := NewStatusV2Processor(tornClient, sheetsClient, bqClient, config.DeployURL)

--- a/internal/application/services/state_tracking_service.go
+++ b/internal/application/services/state_tracking_service.go
@@ -8,42 +8,23 @@ import (
 	"torn_rw_stats/internal/app"
 	"torn_rw_stats/internal/domain/state"
 	"torn_rw_stats/internal/processing"
-	"torn_rw_stats/internal/sheets"
 
 	"github.com/rs/zerolog/log"
 )
 
 // StateTrackingService handles the complete state tracking workflow, detecting
-// and recording member state changes (status, location, travel) to Google Sheets
-// and optionally to BigQuery.
+// and recording member state changes to BigQuery.
 type StateTrackingService struct {
 	tornClient     processing.TornClientInterface
-	sheetsClient   processing.SheetsClientInterface
 	bigqueryClient processing.BigQueryClientInterface // nil = disabled
 	converter      *processing.StateRecordConverter
 	comparator     *processing.StateRecordComparator
 }
 
-// NewStateTrackingService creates a new state tracking service without BigQuery.
-func NewStateTrackingService(tornClient processing.TornClientInterface, sheetsClient processing.SheetsClientInterface) *StateTrackingService {
-	return &StateTrackingService{
-		tornClient:   tornClient,
-		sheetsClient: sheetsClient,
-		converter:    processing.NewStateRecordConverter(),
-		comparator:   processing.NewStateRecordComparator(),
-	}
-}
-
-// NewStateTrackingServiceWithBigQuery creates a state tracking service that also
-// streams state changes to BigQuery. bqClient may be nil to disable BigQuery.
-func NewStateTrackingServiceWithBigQuery(
-	tornClient processing.TornClientInterface,
-	sheetsClient processing.SheetsClientInterface,
-	bqClient processing.BigQueryClientInterface,
-) *StateTrackingService {
+// NewStateTrackingService creates a new state tracking service. bqClient may be nil to disable BigQuery.
+func NewStateTrackingService(tornClient processing.TornClientInterface, bqClient processing.BigQueryClientInterface) *StateTrackingService {
 	return &StateTrackingService{
 		tornClient:     tornClient,
-		sheetsClient:   sheetsClient,
 		bigqueryClient: bqClient,
 		converter:      processing.NewStateRecordConverter(),
 		comparator:     processing.NewStateRecordComparator(),
@@ -68,12 +49,7 @@ func (s *StateTrackingService) ProcessStateChanges(ctx context.Context, spreadsh
 		Int("current_records", len(currentStateRecords)).
 		Msg("Retrieved current state records")
 
-	// Step 2: Ensure Changed States sheet exists
-	if err := s.ensureChangedStatesSheet(ctx, spreadsheetID); err != nil {
-		return fmt.Errorf("failed to ensure Changed States sheet: %w", err)
-	}
-
-	// Step 3: Read previous states — prefer BigQuery (one row per member) over full sheet scan
+	// Step 2: Read previous states from BigQuery
 	var allPreviousStates []app.StateRecord
 	if s.bigqueryClient != nil {
 		memberIDs := make([]string, 0, len(currentStateRecords))
@@ -82,16 +58,7 @@ func (s *StateTrackingService) ProcessStateChanges(ctx context.Context, spreadsh
 		}
 		allPreviousStates, err = s.bigqueryClient.QueryLatestStatePerMember(ctx, memberIDs)
 		if err != nil {
-			log.Warn().Err(err).Msg("BigQuery previous-state query failed, falling back to sheet read")
-			allPreviousStates, err = s.readChangedStatesSheet(ctx, spreadsheetID)
-			if err != nil {
-				return fmt.Errorf("failed to read Changed States sheet: %w", err)
-			}
-		}
-	} else {
-		allPreviousStates, err = s.readChangedStatesSheet(ctx, spreadsheetID)
-		if err != nil {
-			return fmt.Errorf("failed to read Changed States sheet: %w", err)
+			return fmt.Errorf("failed to query previous states from BigQuery: %w", err)
 		}
 	}
 
@@ -99,17 +66,17 @@ func (s *StateTrackingService) ProcessStateChanges(ctx context.Context, spreadsh
 		Int("previous_records", len(allPreviousStates)).
 		Msg("Read previous state records")
 
-	// Step 4: Create previous state collection for comparison
+	// Step 3: Create previous state collection for comparison
 	previousStateRecords := s.comparator.CreatePreviousStateCollection(currentStateRecords, allPreviousStates)
 
 	log.Debug().
 		Int("previous_for_comparison", len(previousStateRecords)).
 		Msg("Created previous states collection for comparison")
 
-	// Step 5: Compare states and find changes
+	// Step 4: Compare states and find changes
 	updatedStateRecords := s.comparator.FindChangedStates(currentStateRecords, s.mapToSlice(previousStateRecords))
 
-	// Step 6: Use domain function to determine action
+	// Step 5: Use domain function to determine action
 	decision := state.DetermineStateChangeAction(currentStateRecords, s.mapToSlice(previousStateRecords), updatedStateRecords)
 
 	log.Info().
@@ -118,15 +85,15 @@ func (s *StateTrackingService) ProcessStateChanges(ctx context.Context, spreadsh
 		Str("reason", decision.Reason).
 		Msg("Determined state change action")
 
-	// Step 7: Execute decision - add updated records to sheet (if decided)
+	// Step 6: Write changed records to BigQuery
 	if decision.ShouldWriteChanges {
-		if err := s.addStateRecords(ctx, spreadsheetID, decision.RecordsToWrite); err != nil {
-			return fmt.Errorf("failed to add state records to sheet: %w", err)
+		if err := s.addStateRecords(ctx, decision.RecordsToWrite); err != nil {
+			return fmt.Errorf("failed to add state records: %w", err)
 		}
 
 		log.Info().
 			Int("records_added", len(decision.RecordsToWrite)).
-			Msg("Successfully added state changes to Changed States sheet")
+			Msg("Successfully added state changes")
 	} else {
 		log.Info().Msg(decision.Reason)
 	}
@@ -139,7 +106,6 @@ func (s *StateTrackingService) getCurrentStateRecords(ctx context.Context, facti
 	var allRecords []app.StateRecord
 
 	for _, factionID := range factionIDs {
-		// Get faction data
 		factionData, err := s.tornClient.GetFactionBasic(ctx, factionID)
 		if err != nil {
 			log.Error().
@@ -149,9 +115,7 @@ func (s *StateTrackingService) getCurrentStateRecords(ctx context.Context, facti
 			continue
 		}
 
-		// Convert faction data to state records
 		records := s.converter.ConvertFromFactionBasic(factionData, currentTime)
-
 		allRecords = append(allRecords, records...)
 
 		log.Debug().
@@ -172,154 +136,10 @@ func (s *StateTrackingService) mapToSlice(recordMap map[string]app.StateRecord) 
 	return slice
 }
 
-// ensureChangedStatesSheet creates the Changed States sheet if it doesn't exist
-func (s *StateTrackingService) ensureChangedStatesSheet(ctx context.Context, spreadsheetID string) error {
-	sheetName := "Changed States"
-
-	exists, err := s.sheetsClient.SheetExists(ctx, spreadsheetID, sheetName)
-	if err != nil {
-		return fmt.Errorf("failed to check if Changed States sheet exists: %w", err)
-	}
-
-	if !exists {
-		if err := s.sheetsClient.CreateSheet(ctx, spreadsheetID, sheetName); err != nil {
-			return fmt.Errorf("failed to create Changed States sheet: %w", err)
-		}
-
-		// Initialize with headers
-		headers := [][]interface{}{
-			{
-				"Timestamp", "Member ID", "Member Name",
-				"Faction ID", "Faction Name", "Last Action Status", "Status Description",
-				"Status State", "Status Until", "Status Travel Type",
-			},
-		}
-
-		rangeSpec := fmt.Sprintf("%s!A1", sheetName)
-		if err := s.sheetsClient.UpdateRange(ctx, spreadsheetID, rangeSpec, headers); err != nil {
-			return fmt.Errorf("failed to write Changed States headers: %w", err)
-		}
-
-		log.Info().Str("sheet_name", sheetName).Msg("Created and initialized Changed States sheet")
-	}
-
-	return nil
-}
-
-// readChangedStatesSheet reads all records from the Changed States sheet
-func (s *StateTrackingService) readChangedStatesSheet(ctx context.Context, spreadsheetID string) ([]app.StateRecord, error) {
-	sheetName := "Changed States"
-	rangeSpec := fmt.Sprintf("%s!A2:J", sheetName) // Skip header row, only 10 columns now
-
-	values, err := s.sheetsClient.ReadSheet(ctx, spreadsheetID, rangeSpec)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read Changed States sheet: %w", err)
-	}
-
-	var records []app.StateRecord
-	for _, row := range values {
-		if len(row) < 8 { // Minimum required: Timestamp through Status State
-			log.Debug().Int("row_length", len(row)).Interface("row", row).Msg("Skipping row with insufficient columns")
-			continue
-		}
-
-		record, err := s.convertRowToStateRecord(row)
-		if err != nil {
-			log.Warn().Err(err).Interface("row", row).Int("row_length", len(row)).Msg("Failed to convert row to StateRecord, skipping")
-			continue
-		}
-
-		records = append(records, record)
-	}
-
-	return records, nil
-}
-
-// addStateRecords adds multiple state records to the Changed States sheet and,
-// if a BigQuery client is configured, streams them to BigQuery as well.
-// A BigQuery failure is non-fatal: the Sheets write is the primary sink.
-func (s *StateTrackingService) addStateRecords(ctx context.Context, spreadsheetID string, records []app.StateRecord) error {
-	if len(records) == 0 {
+// addStateRecords streams state records to BigQuery.
+func (s *StateTrackingService) addStateRecords(ctx context.Context, records []app.StateRecord) error {
+	if len(records) == 0 || s.bigqueryClient == nil {
 		return nil
 	}
-
-	sheetName := "Changed States"
-	var rows [][]interface{}
-
-	for _, record := range records {
-		row := s.convertStateRecordToRow(record)
-		rows = append(rows, row)
-	}
-
-	rangeSpec := fmt.Sprintf("%s!A:J", sheetName)
-	if err := s.sheetsClient.AppendRows(ctx, spreadsheetID, rangeSpec, rows); err != nil {
-		return err
-	}
-
-	if s.bigqueryClient != nil {
-		if err := s.bigqueryClient.InsertStateRecords(ctx, records); err != nil {
-			log.Error().
-				Err(err).
-				Int("record_count", len(records)).
-				Msg("Failed to insert state records into BigQuery — Sheets write succeeded, continuing")
-		}
-	}
-
-	return nil
-}
-
-// convertStateRecordToRow converts a StateRecord into spreadsheet row format
-func (s *StateTrackingService) convertStateRecordToRow(record app.StateRecord) []interface{} {
-	// Format timestamp as human-readable string
-	timestampStr := record.Timestamp.UTC().Format("2006-01-02 15:04:05")
-
-	// Handle StatusUntil - only include if it's a meaningful time (not zero time)
-	var statusUntilStr string
-	if !record.StatusUntil.IsZero() {
-		statusUntilStr = record.StatusUntil.UTC().Format("2006-01-02 15:04:05")
-	}
-
-	return []interface{}{
-		timestampStr, record.MemberID, record.MemberName,
-		record.FactionID, record.FactionName, record.LastActionStatus, record.StatusDescription,
-		record.StatusState, statusUntilStr, record.StatusTravelType,
-	}
-}
-
-// convertRowToStateRecord converts a spreadsheet row into a StateRecord using type-safe Cell
-func (s *StateTrackingService) convertRowToStateRecord(row []interface{}) (app.StateRecord, error) {
-	var record app.StateRecord
-
-	// Parse timestamp (now a string) using type-safe Cell
-	timestampStr := sheets.NewCell(row[0]).String()
-	timestamp, err := time.Parse("2006-01-02 15:04:05", timestampStr)
-	if err != nil {
-		return record, fmt.Errorf("invalid timestamp %q: %w", timestampStr, err)
-	}
-	record.Timestamp = timestamp.UTC()
-
-	// Parse string fields with new column indices using type-safe Cell
-	record.MemberID = sheets.NewCell(row[1]).String()
-	record.MemberName = sheets.NewCell(row[2]).String()
-	record.FactionID = sheets.NewCell(row[3]).String()
-	record.FactionName = sheets.NewCell(row[4]).String()
-	record.LastActionStatus = sheets.NewCell(row[5]).String()
-	record.StatusDescription = sheets.NewCell(row[6]).String()
-	record.StatusState = sheets.NewCell(row[7]).String()
-
-	if len(row) > 9 {
-		record.StatusTravelType = sheets.NewCell(row[9]).String()
-	}
-
-	// Parse StatusUntil - only if not empty
-	if len(row) > 8 {
-		statusUntilStr := sheets.NewCell(row[8]).String()
-		if statusUntilStr != "" {
-			if statusUntil, err := time.Parse("2006-01-02 15:04:05", statusUntilStr); err == nil {
-				record.StatusUntil = statusUntil.UTC()
-			}
-		}
-	}
-
-	return record, nil
+	return s.bigqueryClient.InsertStateRecords(ctx, records)
 }

--- a/internal/application/services/state_tracking_service_test.go
+++ b/internal/application/services/state_tracking_service_test.go
@@ -33,13 +33,9 @@ func TestStateTrackingService_BigQueryCalledWhenClientNonNil(t *testing.T) {
 	tornMock := mocks.NewMockTornClient()
 	tornMock.FactionBasicResponse = factionBasicWithMember(100, "42", "Player1", "okay", "Okay")
 
-	sheetsMock := mocks.NewMockSheetsClient()
-	sheetsMock.SheetExistsResponse = true // Changed States sheet already exists
-	// ReadSheetResponse nil → no previous records → member is "new" → change detected
-
 	bqMock := mocks.NewMockBigQueryClient()
 
-	svc := NewStateTrackingServiceWithBigQuery(tornMock, sheetsMock, bqMock)
+	svc := NewStateTrackingService(tornMock, bqMock)
 	if err := svc.ProcessStateChanges(ctx, "spreadsheet-id", []int{100}); err != nil {
 		t.Fatalf("ProcessStateChanges() returned unexpected error: %v", err)
 	}
@@ -52,39 +48,19 @@ func TestStateTrackingService_BigQueryCalledWhenClientNonNil(t *testing.T) {
 	}
 }
 
-func TestStateTrackingService_BigQuerySkippedWhenClientNil(t *testing.T) {
+func TestStateTrackingService_BigQueryFailureIsFatal(t *testing.T) {
 	ctx := context.Background()
 
 	tornMock := mocks.NewMockTornClient()
 	tornMock.FactionBasicResponse = factionBasicWithMember(100, "42", "Player1", "okay", "Okay")
-
-	sheetsMock := mocks.NewMockSheetsClient()
-	sheetsMock.SheetExistsResponse = true
-
-	// Use the constructor without BigQuery — must not panic
-	svc := NewStateTrackingService(tornMock, sheetsMock)
-	if err := svc.ProcessStateChanges(ctx, "spreadsheet-id", []int{100}); err != nil {
-		t.Fatalf("ProcessStateChanges() returned unexpected error: %v", err)
-	}
-	// No assertion needed beyond "did not panic"
-}
-
-func TestStateTrackingService_BigQueryFailureIsNonFatal(t *testing.T) {
-	ctx := context.Background()
-
-	tornMock := mocks.NewMockTornClient()
-	tornMock.FactionBasicResponse = factionBasicWithMember(100, "42", "Player1", "okay", "Okay")
-
-	sheetsMock := mocks.NewMockSheetsClient()
-	sheetsMock.SheetExistsResponse = true
 
 	bqMock := mocks.NewMockBigQueryClient()
 	bqMock.InsertStateRecordsError = errors.New("simulated BigQuery failure")
 
-	svc := NewStateTrackingServiceWithBigQuery(tornMock, sheetsMock, bqMock)
+	svc := NewStateTrackingService(tornMock, bqMock)
 	err := svc.ProcessStateChanges(ctx, "spreadsheet-id", []int{100})
-	if err != nil {
-		t.Errorf("ProcessStateChanges() should succeed even when BigQuery fails, but got: %v", err)
+	if err == nil {
+		t.Error("ProcessStateChanges() should fail when BigQuery write fails")
 	}
 }
 
@@ -94,9 +70,6 @@ func TestStateTrackingService_BigQueryNotCalledWhenNoChanges(t *testing.T) {
 	tornMock := mocks.NewMockTornClient()
 	tornMock.FactionBasicResponse = factionBasicWithMember(100, "42", "Player1", "okay", "Okay")
 
-	sheetsMock := mocks.NewMockSheetsClient()
-	sheetsMock.SheetExistsResponse = true
-
 	bqMock := mocks.NewMockBigQueryClient()
 	// Return a previous record for the same member with the same state → no change
 	bqMock.QueryLatestStatePerMemberResponse = []app.StateRecord{
@@ -104,7 +77,7 @@ func TestStateTrackingService_BigQueryNotCalledWhenNoChanges(t *testing.T) {
 			LastActionStatus: "Online", StatusDescription: "Okay", StatusState: "okay"},
 	}
 
-	svc := NewStateTrackingServiceWithBigQuery(tornMock, sheetsMock, bqMock)
+	svc := NewStateTrackingService(tornMock, bqMock)
 	if err := svc.ProcessStateChanges(ctx, "spreadsheet-id", []int{100}); err != nil {
 		t.Fatalf("ProcessStateChanges() returned unexpected error: %v", err)
 	}
@@ -118,11 +91,9 @@ func TestStateTrackingService_BigQueryNotCalledForEmptyFactions(t *testing.T) {
 	ctx := context.Background()
 
 	tornMock := mocks.NewMockTornClient()
-	sheetsMock := mocks.NewMockSheetsClient()
-	sheetsMock.SheetExistsResponse = true
 	bqMock := mocks.NewMockBigQueryClient()
 
-	svc := NewStateTrackingServiceWithBigQuery(tornMock, sheetsMock, bqMock)
+	svc := NewStateTrackingService(tornMock, bqMock)
 	// Pass empty faction list — GetFactionBasic should never be called
 	if err := svc.ProcessStateChanges(ctx, "spreadsheet-id", []int{}); err != nil {
 		t.Fatalf("ProcessStateChanges() returned unexpected error: %v", err)

--- a/internal/application/services/status_v2_departure.go
+++ b/internal/application/services/status_v2_departure.go
@@ -6,18 +6,14 @@ import (
 	"time"
 
 	"torn_rw_stats/internal/app"
-	"torn_rw_stats/internal/domain/state"
-	"torn_rw_stats/internal/domain/travel"
 
 	"github.com/rs/zerolog/log"
 )
 
-// buildDepartureMap builds a map of member departure times from state changes.
-// Uses BigQuery when available; falls back to a full sheet scan.
-func (s *StatusV2Service) buildDepartureMap(ctx context.Context, spreadsheetID string, currentStateRecords []app.StateRecord) (map[string]time.Time, error) {
+// buildDepartureMap builds a map of member departure times from BigQuery state changes.
+func (s *StatusV2Service) buildDepartureMap(ctx context.Context, _ string, currentStateRecords []app.StateRecord) (map[string]time.Time, error) {
 	departureMap := make(map[string]time.Time)
 
-	// Collect IDs of currently-traveling members only
 	var travelingIDs []string
 	travelingRecords := make(map[string]app.StateRecord)
 	for _, r := range currentStateRecords {
@@ -26,46 +22,20 @@ func (s *StatusV2Service) buildDepartureMap(ctx context.Context, spreadsheetID s
 			travelingRecords[r.MemberID] = r
 		}
 	}
-	if len(travelingIDs) == 0 {
+	if len(travelingIDs) == 0 || s.bigqueryClient == nil {
 		return departureMap, nil
 	}
 
-	if s.bigqueryClient != nil {
-		times, err := s.bigqueryClient.QueryDepartureTimes(ctx, travelingIDs)
-		if err != nil {
-			log.Warn().Err(err).Msg("BigQuery departure query failed, falling back to sheet scan")
-		} else {
-			for memberID, t := range times {
-				r := travelingRecords[memberID]
-				memberKey := fmt.Sprintf("%s_%s", r.FactionID, memberID)
-				departureMap[memberKey] = t
-			}
-			return departureMap, nil
-		}
-	}
-
-	// Fall back: full sheet scan
-	allStateRecords, err := s.ReadAllStateRecords(ctx, spreadsheetID)
+	times, err := s.bigqueryClient.QueryDepartureTimes(ctx, travelingIDs)
 	if err != nil {
-		return departureMap, fmt.Errorf("failed to read state records: %w", err)
-	}
-	for memberID, currentRecord := range travelingRecords {
-		memberKey := fmt.Sprintf("%s_%s", currentRecord.FactionID, memberID)
-		currentParsedLocation := s.locationService.ParseLocation(currentRecord.StatusDescription)
-		departureTime := s.findMostRecentTravelingTransition(allStateRecords, memberID, currentParsedLocation)
-		if !departureTime.IsZero() {
-			departureMap[memberKey] = departureTime
-		}
+		log.Warn().Err(err).Msg("BigQuery departure query failed")
+		return departureMap, fmt.Errorf("failed to query departure times: %w", err)
 	}
 
+	for memberID, t := range times {
+		r := travelingRecords[memberID]
+		memberKey := fmt.Sprintf("%s_%s", r.FactionID, memberID)
+		departureMap[memberKey] = t
+	}
 	return departureMap, nil
-}
-
-// findMostRecentTravelingTransition finds when a member most recently started traveling to their current destination
-func (s *StatusV2Service) findMostRecentTravelingTransition(allRecords []app.StateRecord, memberID, currentDestination string) time.Time {
-	// Use domain function to filter and sort records
-	memberRecords := state.GetMemberRecordsChronologically(allRecords, memberID)
-
-	// Use domain function to find departure, passing location parser as dependency
-	return travel.FindLastDepartureToDestination(memberRecords, currentDestination, s.locationService.ParseLocation)
 }

--- a/internal/application/services/status_v2_storage.go
+++ b/internal/application/services/status_v2_storage.go
@@ -8,8 +8,6 @@ import (
 
 	"torn_rw_stats/internal/app"
 	"torn_rw_stats/internal/sheets"
-
-	"github.com/rs/zerolog/log"
 )
 
 // getExistingStatusV2Data reads existing Status v2 data to preserve manual adjustments
@@ -76,126 +74,12 @@ func (s *StatusV2Service) getExistingStatusV2Data(ctx context.Context, spreadshe
 	return data, nil
 }
 
-// readCurrentStateRecords returns the latest state record per member for a faction.
-// Uses BigQuery when available; falls back to a full sheet scan.
-func (s *StatusV2Service) readCurrentStateRecords(ctx context.Context, spreadsheetID, factionID string) ([]app.StateRecord, error) {
-	if s.bigqueryClient != nil {
-		records, err := s.bigqueryClient.QueryLatestStatePerFaction(ctx, factionID)
-		if err != nil {
-			log.Warn().Err(err).Str("faction_id", factionID).Msg("BigQuery faction query failed, falling back to sheet scan")
-		} else {
-			return records, nil
-		}
+// readCurrentStateRecords returns the latest state record per member for a faction via BigQuery.
+func (s *StatusV2Service) readCurrentStateRecords(ctx context.Context, _ string, factionID string) ([]app.StateRecord, error) {
+	if s.bigqueryClient == nil {
+		return nil, nil
 	}
-
-	// Fall back: full sheet scan + in-process filter
-	all, err := s.ReadAllStateRecords(ctx, spreadsheetID)
-	if err != nil {
-		return nil, err
-	}
-	memberLatest := make(map[string]app.StateRecord)
-	for _, r := range all {
-		if r.FactionID != factionID {
-			continue
-		}
-		if existing, ok := memberLatest[r.MemberID]; !ok || r.Timestamp.After(existing.Timestamp) {
-			memberLatest[r.MemberID] = r
-		}
-	}
-	result := make([]app.StateRecord, 0, len(memberLatest))
-	for _, r := range memberLatest {
-		result = append(result, r)
-	}
-	return result, nil
-}
-
-// ReadAllStateRecords reads all state records from the Changed States sheet
-func (s *StatusV2Service) ReadAllStateRecords(ctx context.Context, spreadsheetID string) ([]app.StateRecord, error) {
-	sheetName := "Changed States"
-	rangeSpec := fmt.Sprintf("%s!A2:L", sheetName)
-
-	log.Info().
-		Str("sheet_name", sheetName).
-		Str("range_spec", rangeSpec).
-		Msg("Reading state records from Changed States sheet")
-
-	values, err := s.sheetsClient.ReadSheet(ctx, spreadsheetID, rangeSpec)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read Changed States sheet: %w", err)
-	}
-
-	log.Info().
-		Int("raw_rows_read", len(values)).
-		Msg("Successfully read raw data from Changed States sheet")
-
-	var records []app.StateRecord
-	validRows := 0
-	for i, row := range values {
-		if len(row) < 8 {
-			log.Debug().
-				Int("row_index", i).
-				Int("row_length", len(row)).
-				Interface("row_sample", row).
-				Msg("Skipping row with insufficient columns - showing data")
-			continue
-		}
-
-		record, err := s.parseStateRecordFromRow(row)
-		if err != nil {
-			log.Warn().Err(err).Interface("row", row).Msg("Failed to parse state record from row")
-			continue
-		}
-
-		records = append(records, record)
-		validRows++
-	}
-
-	log.Info().
-		Int("total_rows_processed", len(values)).
-		Int("valid_state_records", validRows).
-		Int("final_records_count", len(records)).
-		Msg("Completed reading Changed States data")
-
-	return records, nil
-}
-
-// parseStateRecordFromRow parses a spreadsheet row into a StateRecord
-func (s *StatusV2Service) parseStateRecordFromRow(row []interface{}) (app.StateRecord, error) {
-	var record app.StateRecord
-
-	// Actual Changed States format: [Timestamp, Member ID, Member Name, Faction ID, Faction Name, Last Action Status, Status Description, Status State, Status Until, Status Travel Type]
-	// NOTE: The sheet does NOT have Date and Time columns, so indices are shifted left by 2 from the header definition
-
-	// Parse timestamp from column 0 - this is already formatted as "2025-09-15 1:08:57"
-	if timestampStr, ok := row[0].(string); ok {
-		if timestamp, err := time.Parse("2006-01-02 15:04:05", timestampStr); err == nil {
-			record.Timestamp = timestamp.UTC()
-		}
-	}
-
-	record.MemberID = getString(row, 1)
-	record.MemberName = getString(row, 2)
-	record.FactionID = getString(row, 3)
-	record.FactionName = getString(row, 4)
-	record.LastActionStatus = getString(row, 5)
-	record.StatusDescription = getString(row, 6)
-	record.StatusState = getString(row, 7)
-
-	// Parse StatusUntil from column 8 (optional - only present for some status types)
-	if len(row) > 8 {
-		if statusUntilStr := getString(row, 8); statusUntilStr != "" {
-			if statusUntil, err := time.Parse("2006-01-02 15:04:05", statusUntilStr); err == nil {
-				record.StatusUntil = statusUntil.UTC()
-			}
-		}
-	}
-
-	// Parse StatusTravelType from column 9 (optional - only present for traveling status)
-	if len(row) > 9 {
-		record.StatusTravelType = getString(row, 9)
-	}
-
-	return record, nil
+	return s.bigqueryClient.QueryLatestStatePerFaction(ctx, factionID)
 }
 
 // getString safely gets a string from a spreadsheet row using type-safe Cell wrapper


### PR DESCRIPTION
## Summary

- BigQuery is now the sole sink for state change records
- Removed all sheet writes to the "Changed States" tab (AppendRows, CreateSheet, UpdateRange)
- Removed sheet fallback reads in state tracking, status v2 storage, and departure map building
- Deleted `findMostRecentTravelingTransition` and associated sheet-scan helpers (476 lines deleted)
- BQ write failure is now fatal (was previously non-fatal while sheets was the primary sink)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)