### PR TITLE
chore: replace godotenv with in-house .env loader

### DIFF
--- a/cmd/setup-bigquery/main.go
+++ b/cmd/setup-bigquery/main.go
@@ -24,13 +24,13 @@ import (
 	"os"
 
 	bq "cloud.google.com/go/bigquery"
-	"github.com/joho/godotenv"
+	"torn_rw_stats/internal/app"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 )
 
 func main() {
-	_ = godotenv.Load()
+	_ = app.LoadDotEnv(".env")
 
 	projectID := os.Getenv("BIGQUERY_PROJECT_ID")
 	if projectID == "" {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.25.0
 
 require (
 	cloud.google.com/go/bigquery v1.74.0
-	github.com/joho/godotenv v1.5.1
 	github.com/leanovate/gopter v0.2.11
 	github.com/rs/zerolog v1.34.0
 	golang.org/x/crypto v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,6 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
-github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/joho/godotenv"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
@@ -28,7 +27,7 @@ type Config struct {
 // SetupEnvironment loads .env file and configures zerolog output and log level.
 func SetupEnvironment() {
 	// Load .env file if it exists
-	err := godotenv.Load()
+	err := LoadDotEnv(".env")
 
 	// Configure logging
 	if os.Getenv("ENV") == "production" {

--- a/internal/app/dotenv.go
+++ b/internal/app/dotenv.go
@@ -1,0 +1,48 @@
+package app
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+// loadDotEnv reads KEY=VALUE pairs from filename and sets any that are not
+// already present in the environment. Returns an error if the file cannot be
+// opened; missing files are a normal condition and callers typically ignore
+// the error.
+func LoadDotEnv(filename string) error {
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		value = stripQuotes(value)
+		if key != "" && os.Getenv(key) == "" {
+			os.Setenv(key, value)
+		}
+	}
+	return scanner.Err()
+}
+
+// stripQuotes removes a matched pair of leading/trailing single or double quotes.
+func stripQuotes(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}

--- a/internal/app/dotenv_test.go
+++ b/internal/app/dotenv_test.go
@@ -1,0 +1,103 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeEnvFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestLoadDotEnv(t *testing.T) {
+	t.Run("sets missing vars", func(t *testing.T) {
+		path := writeEnvFile(t, "DOTENV_TEST_KEY=hello\n")
+		os.Unsetenv("DOTENV_TEST_KEY")
+		defer os.Unsetenv("DOTENV_TEST_KEY")
+
+		if err := LoadDotEnv(path); err != nil {
+			t.Fatal(err)
+		}
+		if got := os.Getenv("DOTENV_TEST_KEY"); got != "hello" {
+			t.Errorf("got %q, want %q", got, "hello")
+		}
+	})
+
+	t.Run("does not overwrite existing vars", func(t *testing.T) {
+		path := writeEnvFile(t, "DOTENV_TEST_EXISTING=file_value\n")
+		os.Setenv("DOTENV_TEST_EXISTING", "original")
+		defer os.Unsetenv("DOTENV_TEST_EXISTING")
+
+		if err := LoadDotEnv(path); err != nil {
+			t.Fatal(err)
+		}
+		if got := os.Getenv("DOTENV_TEST_EXISTING"); got != "original" {
+			t.Errorf("got %q, want %q", got, "original")
+		}
+	})
+
+	t.Run("skips comments and blank lines", func(t *testing.T) {
+		path := writeEnvFile(t, "# this is a comment\n\nDOTENV_TEST_COMMENTED=set\n")
+		os.Unsetenv("DOTENV_TEST_COMMENTED")
+		defer os.Unsetenv("DOTENV_TEST_COMMENTED")
+
+		if err := LoadDotEnv(path); err != nil {
+			t.Fatal(err)
+		}
+		if got := os.Getenv("DOTENV_TEST_COMMENTED"); got != "set" {
+			t.Errorf("got %q, want %q", got, "set")
+		}
+	})
+
+	t.Run("strips double quotes", func(t *testing.T) {
+		path := writeEnvFile(t, `DOTENV_TEST_QUOTED="my value"`+"\n")
+		os.Unsetenv("DOTENV_TEST_QUOTED")
+		defer os.Unsetenv("DOTENV_TEST_QUOTED")
+
+		if err := LoadDotEnv(path); err != nil {
+			t.Fatal(err)
+		}
+		if got := os.Getenv("DOTENV_TEST_QUOTED"); got != "my value" {
+			t.Errorf("got %q, want %q", got, "my value")
+		}
+	})
+
+	t.Run("strips single quotes", func(t *testing.T) {
+		path := writeEnvFile(t, "DOTENV_TEST_SQUOTED='my value'\n")
+		os.Unsetenv("DOTENV_TEST_SQUOTED")
+		defer os.Unsetenv("DOTENV_TEST_SQUOTED")
+
+		if err := LoadDotEnv(path); err != nil {
+			t.Fatal(err)
+		}
+		if got := os.Getenv("DOTENV_TEST_SQUOTED"); got != "my value" {
+			t.Errorf("got %q, want %q", got, "my value")
+		}
+	})
+
+	t.Run("returns error for missing file", func(t *testing.T) {
+		if err := LoadDotEnv("/nonexistent/.env"); err == nil {
+			t.Error("expected error for missing file, got nil")
+		}
+	})
+
+	t.Run("value containing equals sign", func(t *testing.T) {
+		path := writeEnvFile(t, "DOTENV_TEST_EQ=a=b=c\n")
+		os.Unsetenv("DOTENV_TEST_EQ")
+		defer os.Unsetenv("DOTENV_TEST_EQ")
+
+		if err := LoadDotEnv(path); err != nil {
+			t.Fatal(err)
+		}
+		if got := os.Getenv("DOTENV_TEST_EQ"); got != "a=b=c" {
+			t.Errorf("got %q, want %q", got, "a=b=c")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Replaces `github.com/joho/godotenv` with a ~40-line in-house implementation in `internal/app/dotenv.go`
- Eliminates one software supply chain dependency entirely
- Handles all formats used in our `.env` files: `KEY=VALUE`, comments, blank lines, quoted values, values containing `=`
- Does not overwrite vars already set in the environment (same behaviour as `godotenv.Load`)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (includes new tests in `dotenv_test.go`)
- [x] `go mod tidy` removes `godotenv` from `go.mod` / `go.sum`
- [x] `golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)