### PR TITLE
chore: replace zerolog with stdlib log/slog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.25.0
 require (
 	cloud.google.com/go/bigquery v1.74.0
 	github.com/leanovate/gopter v0.2.11
-	github.com/rs/zerolog v1.34.0
 	golang.org/x/crypto v0.47.0
 	google.golang.org/api v0.265.0
 )
@@ -29,8 +28,6 @@ require (
 	github.com/googleapis/gax-go/v2 v2.17.0 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.5 // indirect
-	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pierrec/lz4/v4 v4.1.18 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,7 +89,6 @@ github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/T
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -248,14 +247,7 @@ github.com/leanovate/gopter v0.2.11 h1:vRjThO1EKPb/1NsDXuDrzldR28RLkBflWYcU9CvzW
 github.com/leanovate/gopter v0.2.11/go.mod h1:aK3tzZP/C+p1m3SPRE4SYZFGP7jjkuSI4f7Xvpt0S9c=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
-github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
-github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
-github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
-github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
-github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -275,7 +267,6 @@ github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/pierrec/lz4/v4 v4.1.18 h1:xaKrnTkyoqfh1YItXl56+6KJNVYWlEEPuAQW9xsplYQ=
 github.com/pierrec/lz4/v4 v4.1.18/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
@@ -285,9 +276,6 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
-github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
-github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
@@ -528,10 +516,8 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
 golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/telemetry v0.0.0-20251203150158-8fff8a5912fc h1:bH6xUXay0AIFMElXG2rQ4uiE+7ncwtiOdPfYK1NK2XA=

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -2,12 +2,11 @@ package app
 
 import (
 	"fmt"
+	"log/slog"
+	"math"
 	"os"
 	"strings"
 	"time"
-
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 )
 
 // Config holds application configuration
@@ -24,52 +23,58 @@ type Config struct {
 	BigQueryTableID   string
 }
 
-// SetupEnvironment loads .env file and configures zerolog output and log level.
+// LogLevel is the package-level log level variable used by SetupEnvironment.
+var LogLevel slog.LevelVar
+
+// LevelDisabled is a sentinel level that disables all logging.
+const LevelDisabled = slog.Level(math.MaxInt)
+
+// SetupEnvironment loads .env file and configures slog output and log level.
 func SetupEnvironment() {
-	// Load .env file if it exists
 	err := LoadDotEnv(".env")
 
-	// Configure logging
-	if os.Getenv("ENV") == "production" {
-		zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
-		log.Logger = log.Output(os.Stderr)
-	} else {
-		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339})
-	}
-
+	var unknownLevel bool
 	levelStr := strings.ToLower(os.Getenv("LOGLEVEL"))
 	switch levelStr {
 	case "debug":
-		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+		LogLevel.Set(slog.LevelDebug)
 	case "info":
-		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+		LogLevel.Set(slog.LevelInfo)
 	case "warn", "warning":
-		zerolog.SetGlobalLevel(zerolog.WarnLevel)
+		LogLevel.Set(slog.LevelWarn)
 	case "error":
-		zerolog.SetGlobalLevel(zerolog.ErrorLevel)
-	case "fatal":
-		zerolog.SetGlobalLevel(zerolog.FatalLevel)
-	case "panic":
-		zerolog.SetGlobalLevel(zerolog.PanicLevel)
+		LogLevel.Set(slog.LevelError)
+	case "fatal", "panic":
+		LogLevel.Set(slog.LevelError)
 	case "disabled":
-		zerolog.SetGlobalLevel(zerolog.Disabled)
+		LogLevel.Set(LevelDisabled)
 	case "":
-		// Default based on environment
 		if os.Getenv("ENV") == "production" {
-			zerolog.SetGlobalLevel(zerolog.WarnLevel)
+			LogLevel.Set(slog.LevelWarn)
 		} else {
-			zerolog.SetGlobalLevel(zerolog.InfoLevel)
+			LogLevel.Set(slog.LevelInfo)
 		}
 	default:
-		zerolog.SetGlobalLevel(zerolog.InfoLevel)
-		log.Warn().Msgf("Unknown LOGLEVEL '%s', defaulting to info.", levelStr)
+		LogLevel.Set(slog.LevelInfo)
+		unknownLevel = true
 	}
 
-	// wait until now to report on the .env file so we have the chance to set up logging first
-	if err == nil {
-		log.Debug().Msg("Loaded environment variables from .env file.")
+	opts := &slog.HandlerOptions{Level: &LogLevel}
+	var handler slog.Handler
+	if os.Getenv("ENV") == "production" {
+		handler = slog.NewJSONHandler(os.Stderr, opts)
 	} else {
-		log.Debug().Msg("No .env file found or error loading .env file; proceeding with existing environment variables.")
+		handler = slog.NewTextHandler(os.Stderr, opts)
+	}
+	slog.SetDefault(slog.New(handler))
+
+	if unknownLevel {
+		slog.Warn("Unknown LOGLEVEL, defaulting to info", "loglevel", levelStr)
+	}
+	if err == nil {
+		slog.Debug("Loaded environment variables from .env file")
+	} else {
+		slog.Debug("No .env file found; proceeding with existing environment variables")
 	}
 }
 
@@ -110,11 +115,12 @@ func LoadConfig() (*Config, error) {
 	}, nil
 }
 
-// GetRequiredEnv gets an environment variable or panics if not found
+// GetRequiredEnv gets an environment variable or exits if not found
 func GetRequiredEnv(key string) string {
 	value := os.Getenv(key)
 	if value == "" {
-		log.Fatal().Str("key", key).Msg("Required environment variable not set")
+		slog.Error("Required environment variable not set", "key", key)
+		os.Exit(1)
 	}
 	return value
 }

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -1,11 +1,10 @@
 package app
 
 import (
+	"log/slog"
 	"os"
 	"strings"
 	"testing"
-
-	"github.com/rs/zerolog"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -96,34 +95,34 @@ func TestSetupEnvironment(t *testing.T) {
 	// Save original environment
 	originalENV := os.Getenv("ENV")
 	originalLOGLEVEL := os.Getenv("LOGLEVEL")
-	originalLevel := zerolog.GlobalLevel()
+	originalLevel := LogLevel.Level()
 
 	// Cleanup function
 	defer func() {
 		setOrUnset("ENV", originalENV)
 		setOrUnset("LOGLEVEL", originalLOGLEVEL)
-		zerolog.SetGlobalLevel(originalLevel)
+		LogLevel.Set(originalLevel)
 	}()
 
 	testCases := []struct {
 		name          string
 		env           string
 		logLevel      string
-		expectedLevel zerolog.Level
+		expectedLevel slog.Level
 	}{
-		{"ProductionDebug", "production", "debug", zerolog.DebugLevel},
-		{"ProductionInfo", "production", "info", zerolog.InfoLevel},
-		{"ProductionWarn", "production", "warn", zerolog.WarnLevel},
-		{"ProductionWarning", "production", "warning", zerolog.WarnLevel},
-		{"ProductionError", "production", "error", zerolog.ErrorLevel},
-		{"ProductionFatal", "production", "fatal", zerolog.FatalLevel},
-		{"ProductionPanic", "production", "panic", zerolog.PanicLevel},
-		{"ProductionDisabled", "production", "disabled", zerolog.Disabled},
-		{"ProductionDefault", "production", "", zerolog.WarnLevel},
-		{"ProductionUnknown", "production", "unknown", zerolog.InfoLevel},
-		{"DevelopmentDebug", "development", "debug", zerolog.DebugLevel},
-		{"DevelopmentDefault", "development", "", zerolog.InfoLevel},
-		{"DevelopmentUnknown", "", "unknown", zerolog.InfoLevel},
+		{"ProductionDebug", "production", "debug", slog.LevelDebug},
+		{"ProductionInfo", "production", "info", slog.LevelInfo},
+		{"ProductionWarn", "production", "warn", slog.LevelWarn},
+		{"ProductionWarning", "production", "warning", slog.LevelWarn},
+		{"ProductionError", "production", "error", slog.LevelError},
+		{"ProductionFatal", "production", "fatal", slog.LevelError},
+		{"ProductionPanic", "production", "panic", slog.LevelError},
+		{"ProductionDisabled", "production", "disabled", LevelDisabled},
+		{"ProductionDefault", "production", "", slog.LevelWarn},
+		{"ProductionUnknown", "production", "unknown", slog.LevelInfo},
+		{"DevelopmentDebug", "development", "debug", slog.LevelDebug},
+		{"DevelopmentDefault", "development", "", slog.LevelInfo},
+		{"DevelopmentUnknown", "", "unknown", slog.LevelInfo},
 	}
 
 	for _, tc := range testCases {
@@ -133,8 +132,8 @@ func TestSetupEnvironment(t *testing.T) {
 
 			SetupEnvironment()
 
-			if zerolog.GlobalLevel() != tc.expectedLevel {
-				t.Errorf("Expected log level %v, got %v", tc.expectedLevel, zerolog.GlobalLevel())
+			if LogLevel.Level() != tc.expectedLevel {
+				t.Errorf("Expected log level %v, got %v", tc.expectedLevel, LogLevel.Level())
 			}
 		})
 	}
@@ -162,10 +161,10 @@ func TestGetRequiredEnv(t *testing.T) {
 	t.Run("MissingVariable", func(t *testing.T) {
 		os.Unsetenv("TEST_REQUIRED_VAR")
 
-		// This function calls log.Fatal() which would exit the process
+		// This function calls os.Exit(1) which would exit the process
 		// We can't easily test this without complex setup, so we skip it
 		// In a real scenario, you might use dependency injection for the logger
-		t.Skip("Cannot test log.Fatal() without complex test setup")
+		t.Skip("Cannot test os.Exit(1) without complex test setup")
 	})
 }
 

--- a/internal/application/services/api_call_tracker.go
+++ b/internal/application/services/api_call_tracker.go
@@ -2,10 +2,9 @@ package services
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 	"time"
-
-	"github.com/rs/zerolog/log"
 )
 
 // APICallTracker monitors and optimizes API call usage, tracking session statistics,
@@ -75,19 +74,16 @@ func (t *APICallTracker) ResetSession() {
 // LogSessionSummary logs a summary of API usage for the session
 func (t *APICallTracker) LogSessionSummary(ctx context.Context) {
 	stats := t.GetSessionStats()
-
-	logEvent := log.Info().
-		Int64("session_calls", stats.SessionCalls).
-		Int64("total_calls", stats.TotalCalls).
-		Float64("calls_per_minute", stats.CallsPerMinute).
-		Dur("session_duration", stats.SessionDuration)
-
-	// Add breakdown by endpoint
-	for endpoint, count := range stats.CallsByEndpoint {
-		logEvent = logEvent.Int64(endpoint+"_calls", count)
+	args := []any{
+		"session_calls", stats.SessionCalls,
+		"total_calls", stats.TotalCalls,
+		"calls_per_minute", stats.CallsPerMinute,
+		"session_duration", stats.SessionDuration,
 	}
-
-	logEvent.Msg("API call session summary")
+	for endpoint, count := range stats.CallsByEndpoint {
+		args = append(args, endpoint+"_calls", count)
+	}
+	slog.Info("API call session summary", args...)
 }
 
 // APICallStats represents API call statistics for a session, including call counts,

--- a/internal/application/services/optimized_war_processor.go
+++ b/internal/application/services/optimized_war_processor.go
@@ -7,9 +7,9 @@ import (
 
 	"torn_rw_stats/internal/app"
 	"torn_rw_stats/internal/domain/war"
-	"torn_rw_stats/internal/processing"
+	"log/slog"
 
-	"github.com/rs/zerolog/log"
+	"torn_rw_stats/internal/processing"
 )
 
 // OptimizedWarProcessor wraps WarProcessor with intelligent war state management,
@@ -73,8 +73,7 @@ func NewOptimizedWarProcessor(
 // ProcessActiveWars processes wars with continuous monitoring
 func (owp *OptimizedWarProcessor) ProcessActiveWars(ctx context.Context) error {
 	// Always fetch war data first to determine actual current state
-	log.Debug().
-		Msg("Fetching war data to determine current state")
+	slog.Debug("Fetching war data to determine current state")
 
 	warResponse, err := owp.tornClient.GetFactionWars(ctx)
 	if err != nil {
@@ -87,37 +86,33 @@ func (owp *OptimizedWarProcessor) ProcessActiveWars(ctx context.Context) error {
 
 	// Log current state at start of processing loop
 	stateInfo := owp.stateManager.GetStateInfo()
-	log.Info().
-		Str("current_state", stateInfo.State.String()).
-		Str("state_description", stateInfo.Description).
-		Dur("time_in_state", stateInfo.TimeInState).
-		Dur("time_until_next_check", stateInfo.TimeUntilCheck).
-		Msg("Starting war processor loop")
+	slog.Info("Starting war processor loop",
+		"current_state", stateInfo.State.String(),
+		"state_description", stateInfo.Description,
+		"time_in_state", stateInfo.TimeInState,
+		"time_until_next_check", stateInfo.TimeUntilCheck)
 
 	// Continuous monitoring enabled - always process all states
-	log.Debug().
-		Str("current_state", stateInfo.State.String()).
-		Msg("Continuous monitoring enabled - processing all states")
+	slog.Debug("Continuous monitoring enabled - processing all states",
+		"current_state", stateInfo.State.String())
 
 	// Log pre-processing stats
 	preStats := owp.tracker.GetSessionStats()
-	log.Debug().
-		Int64("session_calls_before", preStats.SessionCalls).
-		Msg("API calls before processing")
+	slog.Debug("API calls before processing",
+		"session_calls_before", preStats.SessionCalls)
 
 	// Log state information
 	stateInfo = owp.stateManager.GetStateInfo()
-	log.Info().
-		Str("war_state", currentState.String()).
-		Str("description", stateInfo.Description).
-		Dur("time_in_state", stateInfo.TimeInState).
-		Dur("next_check_in", stateInfo.TimeUntilCheck).
-		Bool("state_changed", previousState != currentState).
-		Msg("War state analysis complete")
+	slog.Info("War state analysis complete",
+		"war_state", currentState.String(),
+		"description", stateInfo.Description,
+		"time_in_state", stateInfo.TimeInState,
+		"next_check_in", stateInfo.TimeUntilCheck,
+		"state_changed", previousState != currentState)
 
 	// Ensure our faction ID is available for state tracking
 	if err := owp.processor.ensureOurFactionID(ctx); err != nil {
-		log.Error().Err(err).Msg("Failed to ensure our faction ID - continuing without state tracking")
+		slog.Error("Failed to ensure our faction ID - continuing without state tracking", "err", err)
 	}
 
 	// Process state changes for all observed factions
@@ -126,28 +121,24 @@ func (owp *OptimizedWarProcessor) ProcessActiveWars(ctx context.Context) error {
 	// Handle different states
 	switch currentState {
 	case war.NoWars:
-		log.Info().
-			Time("next_matchmaking", owp.stateManager.GetNextCheckTime()).
-			Msg("No active wars - processing our faction status only")
+		slog.Info("No active wars - processing our faction status only",
+			"next_matchmaking", owp.stateManager.GetNextCheckTime())
 
 		// Process just our faction's status when no wars exist
 		return owp.processOurFactionOnly(ctx)
 
 	case war.PostWar:
-		log.Info().
-			Time("next_matchmaking", owp.stateManager.GetNextCheckTime()).
-			Msg("War completed - continuing processing for post-war analysis")
+		slog.Info("War completed - continuing processing for post-war analysis",
+			"next_matchmaking", owp.stateManager.GetNextCheckTime())
 
 	case war.PreWar:
-		log.Info().
-			Dur("update_interval", stateInfo.UpdateInterval).
-			Msg("Pre-war reconnaissance mode - monitoring opponent")
+		slog.Info("Pre-war reconnaissance mode - monitoring opponent",
+			"update_interval", stateInfo.UpdateInterval)
 		// Continue to processing for reconnaissance data
 
 	case war.ActiveWar:
-		log.Info().
-			Dur("update_interval", stateInfo.UpdateInterval).
-			Msg("Active war detected - real-time monitoring enabled")
+		slog.Info("Active war detected - real-time monitoring enabled",
+			"update_interval", stateInfo.UpdateInterval)
 		// Continue to full processing
 	}
 
@@ -196,7 +187,7 @@ func (owp *OptimizedWarProcessor) GetProcessingSummary() ProcessingSummary {
 
 // processOurFactionOnly processes just our faction's status when no wars exist
 func (owp *OptimizedWarProcessor) processOurFactionOnly(ctx context.Context) error {
-	log.Info().Msg("Processing our faction status only (no active wars)")
+	slog.Info("Processing our faction status only (no active wars)")
 
 	// Ensure our faction ID is loaded
 	if err := owp.processor.ensureOurFactionID(ctx); err != nil {
@@ -208,9 +199,8 @@ func (owp *OptimizedWarProcessor) processOurFactionOnly(ctx context.Context) err
 		return fmt.Errorf("our faction ID is not set")
 	}
 
-	log.Info().
-		Int("faction_id", ourFactionID).
-		Msg("Successfully processed our faction status")
+	slog.Info("Successfully processed our faction status",
+		"faction_id", ourFactionID)
 
 	return nil
 }
@@ -251,24 +241,21 @@ func (owp *OptimizedWarProcessor) processStateChanges(ctx context.Context, warRe
 
 	// If no factions to track, skip
 	if len(factionIDs) == 0 {
-		log.Debug().Msg("No factions to track for state changes")
+		slog.Debug("No factions to track for state changes")
 		return
 	}
 
 	// Process state changes for all factions (ranked, raids, territory)
-	log.Debug().
-		Ints("faction_ids", factionIDs).
-		Msg("Processing state changes for factions")
+	slog.Debug("Processing state changes for factions",
+		"faction_ids", factionIDs)
 
 	if err := owp.stateTracker.ProcessStateChanges(ctx, owp.spreadsheetID, factionIDs); err != nil {
-		log.Error().
-			Err(err).
-			Ints("faction_ids", factionIDs).
-			Msg("Failed to process state changes - continuing with main processing")
+		slog.Error("Failed to process state changes - continuing with main processing",
+			"err", err,
+			"faction_ids", factionIDs)
 	} else {
-		log.Debug().
-			Ints("faction_ids", factionIDs).
-			Msg("Successfully processed state changes")
+		slog.Debug("Successfully processed state changes",
+			"faction_ids", factionIDs)
 	}
 
 	// Build faction list scoped to ranked war only for the tactical dashboard.
@@ -290,19 +277,16 @@ func (owp *OptimizedWarProcessor) processStateChanges(ctx context.Context, warRe
 	dashboardFactionIDs = owp.removeDuplicateFactionIDs(dashboardFactionIDs)
 
 	// Process Status v2 sheets for ranked war factions only (tactical dashboard)
-	log.Debug().
-		Ints("faction_ids", dashboardFactionIDs).
-		Msg("Processing Status v2 for ranked war factions")
+	slog.Debug("Processing Status v2 for ranked war factions",
+		"faction_ids", dashboardFactionIDs)
 
 	if err := owp.statusV2Processor.ProcessStatusV2ForFactions(ctx, owp.spreadsheetID, dashboardFactionIDs, stateInfo.UpdateInterval); err != nil {
-		log.Error().
-			Err(err).
-			Ints("faction_ids", dashboardFactionIDs).
-			Msg("Failed to process Status v2 - continuing with main processing")
+		slog.Error("Failed to process Status v2 - continuing with main processing",
+			"err", err,
+			"faction_ids", dashboardFactionIDs)
 	} else {
-		log.Debug().
-			Ints("faction_ids", dashboardFactionIDs).
-			Msg("Successfully processed Status v2")
+		slog.Debug("Successfully processed Status v2",
+			"faction_ids", dashboardFactionIDs)
 	}
 }
 

--- a/internal/application/services/state_tracking_service.go
+++ b/internal/application/services/state_tracking_service.go
@@ -7,9 +7,9 @@ import (
 
 	"torn_rw_stats/internal/app"
 	"torn_rw_stats/internal/domain/state"
-	"torn_rw_stats/internal/processing"
+	"log/slog"
 
-	"github.com/rs/zerolog/log"
+	"torn_rw_stats/internal/processing"
 )
 
 // StateTrackingService handles the complete state tracking workflow, detecting
@@ -35,9 +35,8 @@ func NewStateTrackingService(tornClient processing.TornClientInterface, bqClient
 func (s *StateTrackingService) ProcessStateChanges(ctx context.Context, spreadsheetID string, factionIDs []int) error {
 	currentTime := time.Now().UTC()
 
-	log.Info().
-		Int("faction_count", len(factionIDs)).
-		Msg("Starting state change processing")
+	slog.Info("Starting state change processing",
+		"faction_count", len(factionIDs))
 
 	// Step 1: Get current StateRecords for all factions
 	currentStateRecords, err := s.getCurrentStateRecords(ctx, factionIDs, currentTime)
@@ -45,9 +44,8 @@ func (s *StateTrackingService) ProcessStateChanges(ctx context.Context, spreadsh
 		return fmt.Errorf("failed to get current state records: %w", err)
 	}
 
-	log.Debug().
-		Int("current_records", len(currentStateRecords)).
-		Msg("Retrieved current state records")
+	slog.Debug("Retrieved current state records",
+		"current_records", len(currentStateRecords))
 
 	// Step 2: Read previous states from BigQuery
 	var allPreviousStates []app.StateRecord
@@ -62,16 +60,14 @@ func (s *StateTrackingService) ProcessStateChanges(ctx context.Context, spreadsh
 		}
 	}
 
-	log.Debug().
-		Int("previous_records", len(allPreviousStates)).
-		Msg("Read previous state records")
+	slog.Debug("Read previous state records",
+		"previous_records", len(allPreviousStates))
 
 	// Step 3: Create previous state collection for comparison
 	previousStateRecords := s.comparator.CreatePreviousStateCollection(currentStateRecords, allPreviousStates)
 
-	log.Debug().
-		Int("previous_for_comparison", len(previousStateRecords)).
-		Msg("Created previous states collection for comparison")
+	slog.Debug("Created previous states collection for comparison",
+		"previous_for_comparison", len(previousStateRecords))
 
 	// Step 4: Compare states and find changes
 	updatedStateRecords := s.comparator.FindChangedStates(currentStateRecords, s.mapToSlice(previousStateRecords))
@@ -79,11 +75,10 @@ func (s *StateTrackingService) ProcessStateChanges(ctx context.Context, spreadsh
 	// Step 5: Use domain function to determine action
 	decision := state.DetermineStateChangeAction(currentStateRecords, s.mapToSlice(previousStateRecords), updatedStateRecords)
 
-	log.Info().
-		Int("changed_states", decision.ChangeCount).
-		Bool("should_write", decision.ShouldWriteChanges).
-		Str("reason", decision.Reason).
-		Msg("Determined state change action")
+	slog.Info("Determined state change action",
+		"changed_states", decision.ChangeCount,
+		"should_write", decision.ShouldWriteChanges,
+		"reason", decision.Reason)
 
 	// Step 6: Write changed records to BigQuery
 	if decision.ShouldWriteChanges {
@@ -91,11 +86,10 @@ func (s *StateTrackingService) ProcessStateChanges(ctx context.Context, spreadsh
 			return fmt.Errorf("failed to add state records: %w", err)
 		}
 
-		log.Info().
-			Int("records_added", len(decision.RecordsToWrite)).
-			Msg("Successfully added state changes")
+		slog.Info("Successfully added state changes",
+			"records_added", len(decision.RecordsToWrite))
 	} else {
-		log.Info().Msg(decision.Reason)
+		slog.Info(decision.Reason)
 	}
 
 	return nil
@@ -108,20 +102,18 @@ func (s *StateTrackingService) getCurrentStateRecords(ctx context.Context, facti
 	for _, factionID := range factionIDs {
 		factionData, err := s.tornClient.GetFactionBasic(ctx, factionID)
 		if err != nil {
-			log.Error().
-				Err(err).
-				Int("faction_id", factionID).
-				Msg("Failed to get faction data - skipping")
+			slog.Error("Failed to get faction data - skipping",
+				"err", err,
+				"faction_id", factionID)
 			continue
 		}
 
 		records := s.converter.ConvertFromFactionBasic(factionData, currentTime)
 		allRecords = append(allRecords, records...)
 
-		log.Debug().
-			Int("faction_id", factionID).
-			Int("member_count", len(records)).
-			Msg("Retrieved state records for faction")
+		slog.Debug("Retrieved state records for faction",
+			"faction_id", factionID,
+			"member_count", len(records))
 	}
 
 	return allRecords, nil

--- a/internal/application/services/status_v2_departure.go
+++ b/internal/application/services/status_v2_departure.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"torn_rw_stats/internal/app"
+	"log/slog"
 
-	"github.com/rs/zerolog/log"
+	"torn_rw_stats/internal/app"
 )
 
 // buildDepartureMap builds a map of member departure times from BigQuery state changes.
@@ -28,7 +28,7 @@ func (s *StatusV2Service) buildDepartureMap(ctx context.Context, _ string, curre
 
 	times, err := s.bigqueryClient.QueryDepartureTimes(ctx, travelingIDs)
 	if err != nil {
-		log.Warn().Err(err).Msg("BigQuery departure query failed")
+		slog.Warn("BigQuery departure query failed", "err", err)
 		return departureMap, fmt.Errorf("failed to query departure times: %w", err)
 	}
 

--- a/internal/application/services/status_v2_processor.go
+++ b/internal/application/services/status_v2_processor.go
@@ -9,9 +9,9 @@ import (
 
 	"torn_rw_stats/internal/app"
 	"torn_rw_stats/internal/deployment"
-	"torn_rw_stats/internal/processing"
+	"log/slog"
 
-	"github.com/rs/zerolog/log"
+	"torn_rw_stats/internal/processing"
 )
 
 // StatusV2Processor handles Status v2 sheet processing, converting faction member
@@ -50,7 +50,7 @@ func NewStatusV2Processor(tornClient processing.TornClientInterface, sheetsClien
 // ensureOurFactionID fetches and caches our faction ID if not already set
 func (p *StatusV2Processor) ensureOurFactionID(ctx context.Context) error {
 	if p.ourFactionID == 0 {
-		log.Debug().Msg("StatusV2Processor: Fetching our faction ID from API")
+		slog.Debug("StatusV2Processor: Fetching our faction ID from API")
 
 		factionInfo, err := p.tornClient.GetOwnFaction(ctx)
 		if err != nil {
@@ -58,11 +58,10 @@ func (p *StatusV2Processor) ensureOurFactionID(ctx context.Context) error {
 		}
 
 		p.ourFactionID = factionInfo.ID
-		log.Info().
-			Int("faction_id", p.ourFactionID).
-			Str("faction_name", factionInfo.Name).
-			Str("faction_tag", factionInfo.Tag).
-			Msg("StatusV2Processor: Detected our faction ID")
+		slog.Info("StatusV2Processor: Detected our faction ID",
+			"faction_id", p.ourFactionID,
+			"faction_name", factionInfo.Name,
+			"faction_tag", factionInfo.Tag)
 	}
 	return nil
 }
@@ -71,26 +70,23 @@ func (p *StatusV2Processor) ensureOurFactionID(ctx context.Context) error {
 func (p *StatusV2Processor) ProcessStatusV2ForFactions(ctx context.Context, spreadsheetID string, factionIDs []int, updateInterval time.Duration) error {
 	// Ensure our faction ID is loaded for proper filtering
 	if err := p.ensureOurFactionID(ctx); err != nil {
-		log.Error().Err(err).Msg("Failed to fetch our faction ID - continuing but filtering may be incorrect")
+		slog.Error("Failed to fetch our faction ID - continuing but filtering may be incorrect", "err", err)
 	}
 
-	log.Info().
-		Int("faction_count", len(factionIDs)).
-		Int("our_faction_id", p.ourFactionID).
-		Msg("Processing Status v2 for factions")
+	slog.Info("Processing Status v2 for factions",
+		"faction_count", len(factionIDs),
+		"our_faction_id", p.ourFactionID)
 
 	for _, factionID := range factionIDs {
 		if err := p.ProcessStatusV2ForFaction(ctx, spreadsheetID, factionID, updateInterval); err != nil {
-			log.Error().
-				Err(err).
-				Int("faction_id", factionID).
-				Msg("Failed to process Status v2 for faction - continuing with others")
+			slog.Error("Failed to process Status v2 for faction - continuing with others",
+				"err", err,
+				"faction_id", factionID)
 			continue
 		}
 
-		log.Debug().
-			Int("faction_id", factionID).
-			Msg("Successfully processed Status v2 for faction")
+		slog.Debug("Successfully processed Status v2 for faction",
+			"faction_id", factionID)
 	}
 
 	return nil
@@ -114,17 +110,15 @@ func (p *StatusV2Processor) ProcessStatusV2ForFaction(ctx context.Context, sprea
 	factionIDStr := fmt.Sprintf("%d", factionID)
 	currentStateRecords, err := p.service.readCurrentStateRecords(ctx, spreadsheetID, factionIDStr)
 	if err != nil {
-		log.Error().
-			Err(err).
-			Int("faction_id", factionID).
-			Msg("Failed to read state records")
+		slog.Error("Failed to read state records",
+			"err", err,
+			"faction_id", factionID)
 		return fmt.Errorf("failed to read state records: %w", err)
 	}
 
-	log.Info().
-		Int("faction_id", factionID).
-		Int("filtered_state_records", len(currentStateRecords)).
-		Msg("Filtered state records for faction")
+	slog.Info("Filtered state records for faction",
+		"faction_id", factionID,
+		"filtered_state_records", len(currentStateRecords))
 
 	// Step 5: Convert to Status v2 records
 	statusV2Records, err := p.service.ConvertStateRecordsToStatusV2(
@@ -138,23 +132,20 @@ func (p *StatusV2Processor) ProcessStatusV2ForFaction(ctx context.Context, sprea
 		return fmt.Errorf("failed to convert state records to Status v2: %w", err)
 	}
 
-	log.Info().
-		Int("faction_id", factionID).
-		Int("status_v2_records", len(statusV2Records)).
-		Msg("Converted state records to Status v2 records")
+	slog.Info("Converted state records to Status v2 records",
+		"faction_id", factionID,
+		"status_v2_records", len(statusV2Records))
 
 	// Step 6: Update the Status v2 sheet
-	log.Info().
-		Int("faction_id", factionID).
-		Str("sheet_name", sheetName).
-		Int("records_to_write", len(statusV2Records)).
-		Msg("About to update Status v2 sheet")
+	slog.Info("About to update Status v2 sheet",
+		"faction_id", factionID,
+		"sheet_name", sheetName,
+		"records_to_write", len(statusV2Records))
 
 	if len(statusV2Records) == 0 {
-		log.Warn().
-			Int("faction_id", factionID).
-			Str("sheet_name", sheetName).
-			Msg("No Status v2 records to write - sheet will remain empty")
+		slog.Warn("No Status v2 records to write - sheet will remain empty",
+			"faction_id", factionID,
+			"sheet_name", sheetName)
 		return nil
 	}
 
@@ -162,26 +153,23 @@ func (p *StatusV2Processor) ProcessStatusV2ForFaction(ctx context.Context, sprea
 		return fmt.Errorf("failed to update Status v2 sheet: %w", err)
 	}
 
-	log.Info().
-		Int("faction_id", factionID).
-		Int("records_count", len(statusV2Records)).
-		Str("sheet_name", sheetName).
-		Int("state_records_found", len(currentStateRecords)).
-		Int("faction_members", len(factionData.Members)).
-		Msg("Successfully updated Status v2 sheet")
+	slog.Info("Successfully updated Status v2 sheet",
+		"faction_id", factionID,
+		"records_count", len(statusV2Records),
+		"sheet_name", sheetName,
+		"state_records_found", len(currentStateRecords),
+		"faction_members", len(factionData.Members))
 
 	// Step 7: Export JSON alongside sheet update (only for opposing factions)
 	if factionID != p.ourFactionID {
 		if err := p.exportAndDeployJSON(statusV2Records, factionData.Name, factionID, updateInterval); err != nil {
-			log.Warn().
-				Err(err).
-				Int("faction_id", factionID).
-				Msg("Failed to export/deploy Status v2 JSON - continuing with processing")
+			slog.Warn("Failed to export/deploy Status v2 JSON - continuing with processing",
+				"err", err,
+				"faction_id", factionID)
 		}
 	} else {
-		log.Debug().
-			Int("faction_id", factionID).
-			Msg("Skipping JSON export for our own faction")
+		slog.Debug("Skipping JSON export for our own faction",
+			"faction_id", factionID)
 	}
 
 	return nil
@@ -200,11 +188,10 @@ func (p *StatusV2Processor) exportAndDeployJSON(records []app.StatusV2Record, fa
 		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 
-	log.Info().
-		Int("faction_id", factionID).
-		Int("locations_count", len(jsonData.Locations)).
-		Int("json_size_bytes", len(jsonBytes)).
-		Msg("Successfully generated Status v2 JSON")
+	slog.Info("Successfully generated Status v2 JSON",
+		"faction_id", factionID,
+		"locations_count", len(jsonData.Locations),
+		"json_size_bytes", len(jsonBytes))
 
 	// Deploy to remote server if deployer is configured
 	if p.deployer != nil {
@@ -216,15 +203,13 @@ func (p *StatusV2Processor) exportAndDeployJSON(records []app.StatusV2Record, fa
 			return fmt.Errorf("failed to deploy JSON data: %w", err)
 		}
 
-		log.Info().
-			Int("faction_id", factionID).
-			Str("remote_file", remoteFilename).
-			Int("size_bytes", len(jsonBytes)).
-			Msg("Successfully deployed Status v2 JSON")
+		slog.Info("Successfully deployed Status v2 JSON",
+			"faction_id", factionID,
+			"remote_file", remoteFilename,
+			"size_bytes", len(jsonBytes))
 	} else {
-		log.Debug().
-			Int("faction_id", factionID).
-			Msg("No deployer configured - skipping remote deployment")
+		slog.Debug("No deployer configured - skipping remote deployment",
+			"faction_id", factionID)
 	}
 
 	return nil

--- a/internal/application/services/status_v2_service.go
+++ b/internal/application/services/status_v2_service.go
@@ -7,9 +7,9 @@ import (
 	"torn_rw_stats/internal/app"
 	"torn_rw_stats/internal/domain/status"
 	"torn_rw_stats/internal/domain/travel"
-	"torn_rw_stats/internal/processing"
+	"log/slog"
 
-	"github.com/rs/zerolog/log"
+	"torn_rw_stats/internal/processing"
 )
 
 // StatusV2Service handles conversion of StateRecords to StatusV2Records,
@@ -43,51 +43,47 @@ func NewStatusV2ServiceWithBigQuery(sheetsClient processing.SheetsClientInterfac
 // ConvertStateRecordsToStatusV2 converts StateRecords to StatusV2Records
 // incorporating departure time tracking and countdown calculations
 func (s *StatusV2Service) ConvertStateRecordsToStatusV2(ctx context.Context, spreadsheetID string, stateRecords []app.StateRecord, factionMembers map[string]app.FactionMember, factionID int) ([]app.StatusV2Record, error) {
-	log.Info().
-		Int("faction_id", factionID).
-		Int("input_state_records", len(stateRecords)).
-		Int("faction_members", len(factionMembers)).
-		Msg("Starting StateRecord to StatusV2 conversion")
+	slog.Info("Starting StateRecord to StatusV2 conversion",
+		"faction_id", factionID,
+		"input_state_records", len(stateRecords),
+		"faction_members", len(factionMembers))
 
 	var records []app.StatusV2Record
 
 	// Get existing departure data to preserve manual adjustments
 	existingData, err := s.getExistingStatusV2Data(ctx, spreadsheetID, factionID)
 	if err != nil {
-		log.Warn().Err(err).Int("faction_id", factionID).Msg("Failed to get existing Status v2 data, will use defaults")
+		slog.Warn("Failed to get existing Status v2 data, will use defaults", "err", err, "faction_id", factionID)
 		existingData = make(map[string]app.StatusV2Record)
 	}
 
-	log.Debug().
-		Int("faction_id", factionID).
-		Int("existing_status_v2_records", len(existingData)).
-		Msg("Retrieved existing Status v2 data")
+	slog.Debug("Retrieved existing Status v2 data",
+		"faction_id", factionID,
+		"existing_status_v2_records", len(existingData))
 
 	// Get travel state changes for departure time tracking
 	departureMap, err := s.buildDepartureMap(ctx, spreadsheetID, stateRecords)
 	if err != nil {
-		log.Warn().Err(err).Msg("Failed to build departure map, will use current timestamp for traveling players")
+		slog.Warn("Failed to build departure map, will use current timestamp for traveling players", "err", err)
 		departureMap = make(map[string]time.Time)
 	}
 
 	currentTime := time.Now().UTC()
 
 	for i, stateRecord := range stateRecords {
-		log.Debug().
-			Int("faction_id", factionID).
-			Int("record_index", i).
-			Str("member_id", stateRecord.MemberID).
-			Str("member_name", stateRecord.MemberName).
-			Str("status_state", stateRecord.StatusState).
-			Msg("Converting individual state record")
+		slog.Debug("Converting individual state record",
+			"faction_id", factionID,
+			"record_index", i,
+			"member_id", stateRecord.MemberID,
+			"member_name", stateRecord.MemberName,
+			"status_state", stateRecord.StatusState)
 
 		// Skip members who are no longer in the faction
 		if _, exists := factionMembers[stateRecord.MemberID]; !exists {
-			log.Debug().
-				Int("faction_id", factionID).
-				Str("member_id", stateRecord.MemberID).
-				Str("member_name", stateRecord.MemberName).
-				Msg("Skipping member who is no longer in faction")
+			slog.Debug("Skipping member who is no longer in faction",
+				"faction_id", factionID,
+				"member_id", stateRecord.MemberID,
+				"member_name", stateRecord.MemberName)
 			continue
 		}
 
@@ -95,10 +91,9 @@ func (s *StatusV2Service) ConvertStateRecordsToStatusV2(ctx context.Context, spr
 		records = append(records, record)
 	}
 
-	log.Info().
-		Int("faction_id", factionID).
-		Int("output_status_v2_records", len(records)).
-		Msg("Completed StateRecord to StatusV2 conversion")
+	slog.Info("Completed StateRecord to StatusV2 conversion",
+		"faction_id", factionID,
+		"output_status_v2_records", len(records))
 
 	return records, nil
 }

--- a/internal/application/services/war_summary_service.go
+++ b/internal/application/services/war_summary_service.go
@@ -6,9 +6,9 @@ import (
 
 	"torn_rw_stats/internal/app"
 	"torn_rw_stats/internal/domain/attack"
-	wardomain "torn_rw_stats/internal/domain/war"
+	"log/slog"
 
-	"github.com/rs/zerolog/log"
+	wardomain "torn_rw_stats/internal/domain/war"
 )
 
 // WarSummaryService handles war summary generation and statistics calculation,
@@ -56,14 +56,13 @@ func (wss *WarSummaryService) GenerateWarSummary(war *app.War, attacks []app.Att
 	// Set war name based on factions
 	summary.WarName = fmt.Sprintf("%s vs %s", summary.OurFaction.Name, summary.EnemyFaction.Name)
 
-	log.Debug().
-		Int("war_id", war.ID).
-		Int("total_attacks", summary.TotalAttacks).
-		Int("attacks_won", summary.AttacksWon).
-		Int("attacks_lost", summary.AttacksLost).
-		Float64("respect_gained", summary.RespectGained).
-		Float64("respect_lost", summary.RespectLost).
-		Msg("Generated war summary")
+	slog.Debug("Generated war summary",
+		"war_id", war.ID,
+		"total_attacks", summary.TotalAttacks,
+		"attacks_won", summary.AttacksWon,
+		"attacks_lost", summary.AttacksLost,
+		"respect_gained", summary.RespectGained,
+		"respect_lost", summary.RespectLost)
 
 	return summary
 }

--- a/internal/application/services/wars.go
+++ b/internal/application/services/wars.go
@@ -8,11 +8,11 @@ import (
 	"torn_rw_stats/internal/domain/attack"
 	"torn_rw_stats/internal/domain/travel"
 	wardomain "torn_rw_stats/internal/domain/war"
+	"log/slog"
+
 	"torn_rw_stats/internal/processing"
 	"torn_rw_stats/internal/sheets"
 	"torn_rw_stats/internal/torn"
-
-	"github.com/rs/zerolog/log"
 )
 
 // WarProcessor handles war detection and processing, coordinating attack collection,
@@ -73,7 +73,7 @@ func NewOptimizedProcessor(tornClient *torn.Client, sheetsClient *sheets.Client,
 // ensureOurFactionID fetches and caches our faction ID if not already set
 func (wp *WarProcessor) ensureOurFactionID(ctx context.Context) error {
 	if wp.ourFactionID == 0 {
-		log.Debug().Msg("Fetching our faction ID from API")
+		slog.Debug("Fetching our faction ID from API")
 
 		factionInfo, err := wp.tornClient.GetOwnFaction(ctx)
 		if err != nil {
@@ -81,18 +81,17 @@ func (wp *WarProcessor) ensureOurFactionID(ctx context.Context) error {
 		}
 
 		wp.ourFactionID = factionInfo.ID
-		log.Info().
-			Int("faction_id", wp.ourFactionID).
-			Str("faction_name", factionInfo.Name).
-			Str("faction_tag", factionInfo.Tag).
-			Msg("Detected our faction ID")
+		slog.Info("Detected our faction ID",
+			"faction_id", wp.ourFactionID,
+			"faction_name", factionInfo.Name,
+			"faction_tag", factionInfo.Tag)
 	}
 	return nil
 }
 
 // ProcessActiveWars fetches current wars and processes each one
 func (wp *WarProcessor) ProcessActiveWars(ctx context.Context) error {
-	log.Info().Msg("Processing active wars")
+	slog.Info("Processing active wars")
 
 	// Ensure our faction ID is loaded
 	if err := wp.ensureOurFactionID(ctx); err != nil {
@@ -108,15 +107,13 @@ func (wp *WarProcessor) ProcessActiveWars(ctx context.Context) error {
 
 	// Process ranked war if it exists
 	if warResponse.Wars.Ranked != nil {
-		log.Info().
-			Int("war_id", warResponse.Wars.Ranked.ID).
-			Msg("Processing ranked war")
+		slog.Info("Processing ranked war",
+			"war_id", warResponse.Wars.Ranked.ID)
 
 		if err := wp.processWar(ctx, warResponse.Wars.Ranked); err != nil {
-			log.Error().
-				Err(err).
-				Int("war_id", warResponse.Wars.Ranked.ID).
-				Msg("Failed to process ranked war")
+			slog.Error("Failed to process ranked war",
+				"err", err,
+				"war_id", warResponse.Wars.Ranked.ID)
 		} else {
 			processedWars++
 		}
@@ -124,15 +121,13 @@ func (wp *WarProcessor) ProcessActiveWars(ctx context.Context) error {
 
 	// Process raid wars
 	for _, war := range warResponse.Wars.Raids {
-		log.Info().
-			Int("war_id", war.ID).
-			Msg("Processing raid war")
+		slog.Info("Processing raid war",
+			"war_id", war.ID)
 
 		if err := wp.processWar(ctx, &war); err != nil {
-			log.Error().
-				Err(err).
-				Int("war_id", war.ID).
-				Msg("Failed to process raid war")
+			slog.Error("Failed to process raid war",
+				"err", err,
+				"war_id", war.ID)
 		} else {
 			processedWars++
 		}
@@ -140,34 +135,30 @@ func (wp *WarProcessor) ProcessActiveWars(ctx context.Context) error {
 
 	// Process territory wars
 	for _, war := range warResponse.Wars.Territory {
-		log.Info().
-			Int("war_id", war.ID).
-			Msg("Processing territory war")
+		slog.Info("Processing territory war",
+			"war_id", war.ID)
 
 		if err := wp.processWar(ctx, &war); err != nil {
-			log.Error().
-				Err(err).
-				Int("war_id", war.ID).
-				Msg("Failed to process territory war")
+			slog.Error("Failed to process territory war",
+				"err", err,
+				"war_id", war.ID)
 		} else {
 			processedWars++
 		}
 	}
 
-	log.Info().
-		Int("processed_wars", processedWars).
-		Msg("Completed processing active wars")
+	slog.Info("Completed processing active wars",
+		"processed_wars", processedWars)
 
 	return nil
 }
 
 // processWar handles processing a single war
 func (wp *WarProcessor) processWar(ctx context.Context, war *app.War) error {
-	log.Info().
-		Int("war_id", war.ID).
-		Int("factions_count", len(war.Factions)).
-		Int64("start_time", war.Start).
-		Msg("=== ENTERING processWar ===")
+	slog.Info("=== ENTERING processWar ===",
+		"war_id", war.ID,
+		"factions_count", len(war.Factions),
+		"start_time", war.Start)
 
 	// Ensure sheets exist for this war
 	sheetConfig, err := wp.sheetsClient.EnsureWarSheets(ctx, wp.config.SpreadsheetID, war)
@@ -183,12 +174,11 @@ func (wp *WarProcessor) processWar(ctx context.Context, war *app.War) error {
 
 	// Use domain function to determine fetch mode
 	fetchDecision := wardomain.DetermineAttackFetchMode(existingInfo.RecordCount, existingInfo.LatestTimestamp)
-	log.Debug().
-		Int("war_id", war.ID).
-		Bool("use_full_mode", fetchDecision.UseFullMode).
-		Bool("use_incremental", fetchDecision.UseIncremental).
-		Str("reason", fetchDecision.Reason).
-		Msg("Determined attack fetch mode")
+	slog.Debug("Determined attack fetch mode",
+		"war_id", war.ID,
+		"use_full_mode", fetchDecision.UseFullMode,
+		"use_incremental", fetchDecision.UseIncremental,
+		"reason", fetchDecision.Reason)
 
 	// Fetch attacks based on decision
 	var attacks []app.Attack
@@ -203,10 +193,9 @@ func (wp *WarProcessor) processWar(ctx context.Context, war *app.War) error {
 		return fmt.Errorf("failed to fetch attacks for war: %w", err)
 	}
 
-	log.Debug().
-		Int("war_id", war.ID).
-		Int("attacks_count", len(attacks)).
-		Msg("Fetched attacks for war")
+	slog.Debug("Fetched attacks for war",
+		"war_id", war.ID,
+		"attacks_count", len(attacks))
 
 	// Get our faction ID for processing
 	ourFactionID := wp.getOurFactionID(war)
@@ -225,11 +214,10 @@ func (wp *WarProcessor) processWar(ctx context.Context, war *app.War) error {
 	}
 
 	if len(duplicateRecords) > 0 {
-		log.Error().
-			Int("total_records", len(records)).
-			Int("duplicate_codes", len(duplicateRecords)).
-			Strs("duplicate_records", duplicateRecords).
-			Msg("=== DUPLICATES DETECTED IN PROCESSED RECORDS ===")
+		slog.Error("=== DUPLICATES DETECTED IN PROCESSED RECORDS ===",
+			"total_records", len(records),
+			"duplicate_codes", len(duplicateRecords),
+			"duplicate_records", duplicateRecords)
 	}
 
 	// Generate war summary
@@ -244,11 +232,10 @@ func (wp *WarProcessor) processWar(ctx context.Context, war *app.War) error {
 		return fmt.Errorf("failed to update attack records: %w", err)
 	}
 
-	log.Info().
-		Int("war_id", war.ID).
-		Int("attacks_processed", len(attacks)).
-		Int("records_created", len(records)).
-		Msg("=== EXITING processWar - Successfully processed war ===")
+	slog.Info("=== EXITING processWar - Successfully processed war ===",
+		"war_id", war.ID,
+		"attacks_processed", len(attacks),
+		"records_created", len(records))
 
 	return nil
 }

--- a/internal/bigquery/client.go
+++ b/internal/bigquery/client.go
@@ -3,10 +3,10 @@ package bigquery
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	bq "cloud.google.com/go/bigquery"
-	"github.com/rs/zerolog/log"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 
@@ -136,11 +136,10 @@ WHERE rn = 1`,
 		records = append(records, r)
 	}
 
-	log.Debug().
-		Int("members_queried", len(memberIDs)).
-		Int("records_returned", len(records)).
-		Dur("duration", time.Since(start)).
-		Msg("BigQuery latest-state-per-member query complete")
+	slog.Debug("BigQuery latest-state-per-member query complete",
+		"members_queried", len(memberIDs),
+		"records_returned", len(records),
+		"duration", time.Since(start))
 
 	return records, nil
 }
@@ -211,11 +210,10 @@ WHERE rn = 1`,
 		records = append(records, r)
 	}
 
-	log.Debug().
-		Str("faction_id", factionID).
-		Int("records_returned", len(records)).
-		Dur("duration", time.Since(start)).
-		Msg("BigQuery latest-state-per-faction query complete")
+	slog.Debug("BigQuery latest-state-per-faction query complete",
+		"faction_id", factionID,
+		"records_returned", len(records),
+		"duration", time.Since(start))
 
 	return records, nil
 }
@@ -270,11 +268,10 @@ QUALIFY ROW_NUMBER() OVER (PARTITION BY member_id ORDER BY timestamp DESC) = 1`,
 		result[row.MemberID] = row.DepartureTime.UTC()
 	}
 
-	log.Debug().
-		Int("members_queried", len(memberIDs)).
-		Int("departures_found", len(result)).
-		Dur("duration", time.Since(start)).
-		Msg("BigQuery departure-times query complete")
+	slog.Debug("BigQuery departure-times query complete",
+		"members_queried", len(memberIDs),
+		"departures_found", len(result),
+		"duration", time.Since(start))
 
 	return result, nil
 }
@@ -296,12 +293,11 @@ func (c *Client) InsertStateRecords(ctx context.Context, records []app.StateReco
 		return fmt.Errorf("bigquery insert failed (dataset=%s table=%s): %w", c.datasetID, c.tableID, err)
 	}
 
-	log.Debug().
-		Int("rows", len(records)).
-		Dur("duration", time.Since(start)).
-		Str("dataset", c.datasetID).
-		Str("table", c.tableID).
-		Msg("BigQuery streaming insert complete")
+	slog.Debug("BigQuery streaming insert complete",
+		"rows", len(records),
+		"duration", time.Since(start),
+		"dataset", c.datasetID,
+		"table", c.tableID)
 
 	return nil
 }

--- a/internal/deployment/ssh_deployer.go
+++ b/internal/deployment/ssh_deployer.go
@@ -9,7 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rs/zerolog/log"
+	"log/slog"
+
 	"golang.org/x/crypto/ssh"
 )
 
@@ -67,7 +68,7 @@ func (d *SSHDeployer) parseDeployURL() (user, host, remotePath string, err error
 func (d *SSHDeployer) Connect() error {
 	if d.connected {
 		if err := d.Disconnect(); err != nil {
-			log.Warn().Err(err).Msg("Failed to disconnect before reconnecting")
+			slog.Warn("Failed to disconnect before reconnecting", "err", err)
 		}
 	}
 
@@ -105,10 +106,9 @@ func (d *SSHDeployer) Connect() error {
 	}
 
 	d.connected = true
-	log.Info().
-		Str("host", host).
-		Str("user", user).
-		Msg("Successfully connected to SSH server")
+	slog.Info("Successfully connected to SSH server",
+		"host", host,
+		"user", user)
 
 	return nil
 }
@@ -135,7 +135,7 @@ func (d *SSHDeployer) DeployData(data io.Reader, size int64, filename string) er
 	}
 	defer func() {
 		if err := d.Disconnect(); err != nil {
-			log.Warn().Err(err).Msg("Failed to disconnect SSH after deployment")
+			slog.Warn("Failed to disconnect SSH after deployment", "err", err)
 		}
 	}()
 
@@ -195,10 +195,9 @@ func (d *SSHDeployer) DeployData(data io.Reader, size int64, filename string) er
 		return fmt.Errorf("SCP session failed: %w", err)
 	}
 
-	log.Info().
-		Str("remote_path", remoteFilePath).
-		Int64("size", size).
-		Msg("Successfully deployed data via SCP")
+	slog.Info("Successfully deployed data via SCP",
+		"remote_path", remoteFilePath,
+		"size", size)
 
 	return nil
 }

--- a/internal/domain/attack/attack_service.go
+++ b/internal/domain/attack/attack_service.go
@@ -3,9 +3,9 @@ package attack
 import (
 	"time"
 
-	"torn_rw_stats/internal/app"
+	"log/slog"
 
-	"github.com/rs/zerolog/log"
+	"torn_rw_stats/internal/app"
 )
 
 // AttackProcessingService handles attack data processing and analysis, converting
@@ -75,11 +75,10 @@ func (aps *AttackProcessingService) ProcessAttacksIntoRecords(attacks []app.Atta
 		records = append(records, record)
 	}
 
-	log.Debug().
-		Int("total_attacks", len(attacks)).
-		Int("records_created", len(records)).
-		Int("our_faction_id", ourFactionID).
-		Msg("Processed attacks into records")
+	slog.Debug("Processed attacks into records",
+		"total_attacks", len(attacks),
+		"records_created", len(records),
+		"our_faction_id", ourFactionID)
 
 	return records
 }

--- a/internal/domain/travel/travel_time_service.go
+++ b/internal/domain/travel/travel_time_service.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/rs/zerolog/log"
+	"log/slog"
 )
 
 const (
@@ -92,10 +92,9 @@ func (tts *TravelTimeService) GetTravelTime(destination string, travelType strin
 	}
 
 	if minutes == 0 {
-		log.Warn().
-			Str("destination", destination).
-			Str("travel_type", travelType).
-			Msg("Unknown travel destination, using default time")
+		slog.Warn("Unknown travel destination, using default time",
+			"destination", destination,
+			"travel_type", travelType)
 		return DefaultTravelTimeFallback
 	}
 
@@ -143,14 +142,13 @@ func (tts *TravelTimeService) CalculateTravelTimes(ctx context.Context, userID i
 		countdown = "00:00:00"
 	}
 
-	log.Debug().
-		Int("user_id", userID).
-		Str("destination", destination).
-		Str("travel_type", travelType).
-		Dur("travel_duration", travelDuration).
-		Str("business_arrival", businessArrival).
-		Str("countdown", countdown).
-		Msg("Calculated travel times")
+	slog.Debug("Calculated travel times",
+		"user_id", userID,
+		"destination", destination,
+		"travel_type", travelType,
+		"travel_duration", travelDuration,
+		"business_arrival", businessArrival,
+		"countdown", countdown)
 
 	return &TravelTimeData{
 		Departure:       estimatedDepartureTime.UTC().Format("2006-01-02 15:04:05"),
@@ -165,11 +163,10 @@ func (tts *TravelTimeService) CalculateTravelTimesFromDeparture(ctx context.Cont
 	// Parse existing departure time as UTC to match how times are stored
 	departureTime, err := time.ParseInLocation("2006-01-02 15:04:05", departureStr, time.UTC)
 	if err != nil {
-		log.Warn().
-			Err(err).
-			Str("departure_str", departureStr).
-			Int("user_id", userID).
-			Msg("Failed to parse existing departure time")
+		slog.Warn("Failed to parse existing departure time",
+			"err", err,
+			"departure_str", departureStr,
+			"user_id", userID)
 		return nil
 	}
 
@@ -182,10 +179,9 @@ func (tts *TravelTimeService) CalculateTravelTimesFromDeparture(ctx context.Cont
 			arrivalTime = parsedArrival
 			travelDuration = arrivalTime.Sub(departureTime)
 		} else {
-			log.Warn().
-				Err(err).
-				Str("existing_arrival_str", existingArrivalStr).
-				Msg("Failed to parse existing arrival time, falling back to calculation")
+			slog.Warn("Failed to parse existing arrival time, falling back to calculation",
+				"err", err,
+				"existing_arrival_str", existingArrivalStr)
 		}
 	}
 
@@ -215,16 +211,15 @@ func (tts *TravelTimeService) CalculateTravelTimesFromDeparture(ctx context.Cont
 		countdown = "00:00:00"
 	}
 
-	log.Debug().
-		Int("user_id", userID).
-		Str("destination", destination).
-		Str("travel_type", travelType).
-		Dur("travel_duration", travelDuration).
-		Str("departure", departureStr).
-		Str("arrival", arrivalTime.UTC().Format("2006-01-02 15:04:05")).
-		Str("business_arrival", businessArrival).
-		Str("countdown", countdown).
-		Msg("Recalculated travel times from existing departure")
+	slog.Debug("Recalculated travel times from existing departure",
+		"user_id", userID,
+		"destination", destination,
+		"travel_type", travelType,
+		"travel_duration", travelDuration,
+		"departure", departureStr,
+		"arrival", arrivalTime.UTC().Format("2006-01-02 15:04:05"),
+		"business_arrival", businessArrival,
+		"countdown", countdown)
 
 	return &TravelTimeData{
 		Departure:       departureStr, // Keep original departure time

--- a/internal/domain/war/war_state_manager.go
+++ b/internal/domain/war/war_state_manager.go
@@ -3,9 +3,9 @@ package war
 import (
 	"time"
 
-	"torn_rw_stats/internal/app"
+	"log/slog"
 
-	"github.com/rs/zerolog/log"
+	"torn_rw_stats/internal/app"
 )
 
 // Configuration constants for war state management
@@ -139,21 +139,19 @@ func (wsm *WarStateManager) UpdateState(warResponse *app.WarResponse) WarState {
 	// Validate state transition to prevent oscillation
 	if wsm.isValidStateTransition(wsm.currentState, newState) {
 		if newState != wsm.currentState {
-			log.Info().
-				Str("previous_state", wsm.currentState.String()).
-				Str("new_state", newState.String()).
-				Dur("time_in_previous_state", time.Since(wsm.lastStateChange)).
-				Msg("War state transition")
+			slog.Info("War state transition",
+				"previous_state", wsm.currentState.String(),
+				"new_state", newState.String(),
+				"time_in_previous_state", time.Since(wsm.lastStateChange))
 
 			wsm.currentState = newState
 			wsm.lastStateChange = time.Now()
 		}
 	} else {
-		log.Debug().
-			Str("current_state", wsm.currentState.String()).
-			Str("attempted_state", newState.String()).
-			Dur("time_since_last_change", time.Since(wsm.lastStateChange)).
-			Msg("Invalid state transition blocked")
+		slog.Debug("Invalid state transition blocked",
+			"current_state", wsm.currentState.String(),
+			"attempted_state", newState.String(),
+			"time_since_last_change", time.Since(wsm.lastStateChange))
 	}
 
 	return wsm.currentState
@@ -347,10 +345,9 @@ func (wsm *WarStateManager) GetNextCheckTime() time.Time {
 		if wsm.currentState == PreWar && wsm.currentWarIsRanked && wsm.currentWar != nil {
 			warStart := time.Unix(wsm.currentWar.Start, 0)
 			if time.Until(warStart) <= PreWarRealTimeThreshold {
-				log.Debug().
-					Time("war_start", warStart).
-					Dur("time_until_start", time.Until(warStart)).
-					Msg("Within 12h of ranked war start - accelerating to real-time polling")
+				slog.Debug("Within 12h of ranked war start - accelerating to real-time polling",
+					"war_start", warStart,
+					"time_until_start", time.Until(warStart))
 				return now.Add(ActiveWarUpdateInterval)
 			}
 		}

--- a/internal/sheets/client.go
+++ b/internal/sheets/client.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/rs/zerolog/log"
+	"log/slog"
+
 	"google.golang.org/api/option"
 	"google.golang.org/api/sheets/v4"
 )
@@ -178,15 +179,14 @@ func (c *Client) EnsureSheetCapacity(ctx context.Context, spreadsheetID, sheetNa
 		return nil
 	}
 
-	log.Debug().
-		Str("sheet_name", sheetName).
-		Int("current_rows", currentRows).
-		Int("current_cols", currentCols).
-		Int("required_rows", requiredRows).
-		Int("required_cols", requiredCols).
-		Int("new_rows", newRows).
-		Int("new_cols", newCols).
-		Msg("Expanding sheet capacity")
+	slog.Debug("Expanding sheet capacity",
+		"sheet_name", sheetName,
+		"current_rows", currentRows,
+		"current_cols", currentCols,
+		"required_rows", requiredRows,
+		"required_cols", requiredCols,
+		"new_rows", newRows,
+		"new_cols", newCols)
 
 	req := &sheets.Request{
 		UpdateSheetProperties: &sheets.UpdateSheetPropertiesRequest{
@@ -212,11 +212,10 @@ func (c *Client) EnsureSheetCapacity(ctx context.Context, spreadsheetID, sheetNa
 		return fmt.Errorf("failed to resize sheet %s: %w", sheetName, err)
 	}
 
-	log.Info().
-		Str("sheet_name", sheetName).
-		Int("new_rows", newRows).
-		Int("new_cols", newCols).
-		Msg("Successfully expanded sheet capacity")
+	slog.Info("Successfully expanded sheet capacity",
+		"sheet_name", sheetName,
+		"new_rows", newRows,
+		"new_cols", newCols)
 
 	return nil
 }
@@ -224,8 +223,7 @@ func (c *Client) EnsureSheetCapacity(ctx context.Context, spreadsheetID, sheetNa
 // FormatStatusSheet is disabled - formatting is handled manually in Google Sheets
 // We only keep the apostrophe prefix in travel time formatting to prevent decimal conversion
 func (c *Client) FormatStatusSheet(ctx context.Context, spreadsheetID, sheetName string) error {
-	log.Debug().
-		Str("sheet_name", sheetName).
-		Msg("Skipping automatic formatting - handled manually")
+	slog.Debug("Skipping automatic formatting - handled manually",
+		"sheet_name", sheetName)
 	return nil
 }

--- a/internal/sheets/records_processor.go
+++ b/internal/sheets/records_processor.go
@@ -8,7 +8,7 @@ import (
 
 	"torn_rw_stats/internal/app"
 
-	"github.com/rs/zerolog/log"
+	"log/slog"
 )
 
 // AttackRecordsProcessor handles business logic for attack records management
@@ -34,9 +34,8 @@ type RecordsInfo struct {
 
 // ReadExistingRecords reads existing attack records from a sheet to determine what's already there
 func (p *AttackRecordsProcessor) ReadExistingRecords(ctx context.Context, spreadsheetID, sheetName string) (*RecordsInfo, error) {
-	log.Debug().
-		Str("sheet_name", sheetName).
-		Msg("Reading existing attack records")
+	slog.Debug("Reading existing attack records",
+		"sheet_name", sheetName)
 
 	// Read all data from the sheet (starting from row 2 to skip headers)
 	rangeSpec := fmt.Sprintf("'%s'!A2:AF", sheetName)
@@ -79,19 +78,17 @@ func (p *AttackRecordsProcessor) ReadExistingRecords(ctx context.Context, spread
 	info.RecordCount = validRows
 	info.LastRowProcessed = len(values) + 1 // +1 for header row
 
-	log.Debug().
-		Int("total_rows_read", len(values)).
-		Int("valid_records", info.RecordCount).
-		Int("unique_attack_codes", len(info.AttackCodes)).
-		Int64("latest_timestamp", info.LatestTimestamp).
-		Str("latest_time", time.Unix(info.LatestTimestamp, 0).Format("2006-01-02 15:04:05")).
-		Msg("Analyzed existing records")
+	slog.Debug("Analyzed existing records",
+		"total_rows_read", len(values),
+		"valid_records", info.RecordCount,
+		"unique_attack_codes", len(info.AttackCodes),
+		"latest_timestamp", info.LatestTimestamp,
+		"latest_time", time.Unix(info.LatestTimestamp, 0).Format("2006-01-02 15:04:05"))
 
 	// Validation: warn if no attack codes were parsed from non-empty sheet
 	if len(values) > 0 && len(info.AttackCodes) == 0 {
-		log.Warn().
-			Int("rows_in_sheet", len(values)).
-			Msg("No attack codes parsed from existing sheet - possible column mismatch")
+		slog.Warn("No attack codes parsed from existing sheet - possible column mismatch",
+			"rows_in_sheet", len(values))
 	}
 
 	return info, nil
@@ -103,11 +100,10 @@ func (p *AttackRecordsProcessor) UpdateAttackRecords(ctx context.Context, spread
 		return nil
 	}
 
-	log.Info().
-		Int("war_id", config.WarID).
-		Str("sheet_name", config.RecordsTabName).
-		Int("records_count", len(records)).
-		Msg("=== ENTERING UpdateAttackRecords ===")
+	slog.Info("=== ENTERING UpdateAttackRecords ===",
+		"war_id", config.WarID,
+		"sheet_name", config.RecordsTabName,
+		"records_count", len(records))
 
 	// Read existing records to determine update strategy
 	existing, err := p.ReadExistingRecords(ctx, spreadsheetID, config.RecordsTabName)
@@ -116,24 +112,22 @@ func (p *AttackRecordsProcessor) UpdateAttackRecords(ctx context.Context, spread
 	}
 
 	// Filter out duplicate attacks and sort chronologically
-	log.Debug().
-		Int("input_records", len(records)).
-		Int("existing_attack_codes", len(existing.AttackCodes)).
-		Int("existing_record_count", existing.RecordCount).
-		Msg("Starting deduplication")
+	slog.Debug("Starting deduplication",
+		"input_records", len(records),
+		"existing_attack_codes", len(existing.AttackCodes),
+		"existing_record_count", existing.RecordCount)
 
 	newRecords := p.FilterAndSortRecords(records, existing)
 
 	if len(newRecords) == 0 {
-		log.Info().Msg("=== EXITING UpdateAttackRecords - No new records after deduplication ===")
+		slog.Info("=== EXITING UpdateAttackRecords - No new records after deduplication ===")
 		return nil
 	}
 
-	log.Info().
-		Int("original_records", len(records)).
-		Int("new_records", len(newRecords)).
-		Int("existing_records", existing.RecordCount).
-		Msg("Processed records for update")
+	slog.Info("Processed records for update",
+		"original_records", len(records),
+		"new_records", len(newRecords),
+		"existing_records", existing.RecordCount)
 
 	// Convert to spreadsheet format
 	rows := p.ConvertRecordsToRows(newRecords)
@@ -163,11 +157,10 @@ func (p *AttackRecordsProcessor) UpdateAttackRecords(ctx context.Context, spread
 		}
 	}
 
-	log.Info().
-		Str("range", rangeSpec).
-		Int("rows_to_write", len(rows)).
-		Strs("sample_rows", sampleRows).
-		Msg("=== WRITING TO SHEET ===")
+	slog.Info("=== WRITING TO SHEET ===",
+		"range", rangeSpec,
+		"rows_to_write", len(rows),
+		"sample_rows", sampleRows)
 
 	// Use UpdateRange instead of AppendRows for exact range specification
 	err = p.api.UpdateRange(ctx, spreadsheetID, rangeSpec, rows)
@@ -175,11 +168,10 @@ func (p *AttackRecordsProcessor) UpdateAttackRecords(ctx context.Context, spread
 		return fmt.Errorf("failed to append attack records: %w", err)
 	}
 
-	log.Info().
-		Int("war_id", config.WarID).
-		Int("records_appended", len(newRecords)).
-		Str("range", rangeSpec).
-		Msg("=== EXITING UpdateAttackRecords - Successfully appended records ===")
+	slog.Info("=== EXITING UpdateAttackRecords - Successfully appended records ===",
+		"war_id", config.WarID,
+		"records_appended", len(newRecords),
+		"range", rangeSpec)
 
 	return nil
 }
@@ -194,21 +186,19 @@ func (p *AttackRecordsProcessor) FilterAndSortRecords(records []app.AttackRecord
 		// Skip if duplicate attack code
 		if existing.AttackCodes[record.Code] {
 			duplicates++
-			log.Debug().
-				Str("attack_code", record.Code).
-				Int64("attack_id", record.AttackID).
-				Msg("Filtered duplicate attack")
+			slog.Debug("Filtered duplicate attack",
+				"attack_code", record.Code,
+				"attack_id", record.AttackID)
 			continue
 		}
 
 		// Skip if record is older than or equal to existing timestamp (already processed)
 		if record.Started.Unix() <= existing.LatestTimestamp {
 			duplicates++
-			log.Debug().
-				Int64("attack_id", record.AttackID).
-				Int64("record_timestamp", record.Started.Unix()).
-				Int64("existing_timestamp", existing.LatestTimestamp).
-				Msg("Filtered old attack (timestamp)")
+			slog.Debug("Filtered old attack (timestamp)",
+				"attack_id", record.AttackID,
+				"record_timestamp", record.Started.Unix(),
+				"existing_timestamp", existing.LatestTimestamp)
 			continue
 		}
 
@@ -226,21 +216,19 @@ func (p *AttackRecordsProcessor) FilterAndSortRecords(records []app.AttackRecord
 		}
 	}
 
-	log.Info().
-		Int("input_records", len(records)).
-		Int("duplicates_filtered", duplicates).
-		Int("new_records", len(newRecords)).
-		Strs("sample_attack_codes", sampleCodes).
-		Msg("Completed deduplication filtering")
+	slog.Info("Completed deduplication filtering",
+		"input_records", len(records),
+		"duplicates_filtered", duplicates,
+		"new_records", len(newRecords),
+		"sample_attack_codes", sampleCodes)
 
 	// Sort chronologically (oldest first)
 	sort.Slice(newRecords, func(i, j int) bool {
 		return newRecords[i].Started.Before(newRecords[j].Started)
 	})
 
-	log.Debug().
-		Int("filtered_records", len(newRecords)).
-		Msg("Filtered and sorted records chronologically")
+	slog.Debug("Filtered and sorted records chronologically",
+		"filtered_records", len(newRecords))
 
 	return newRecords
 }

--- a/internal/sheets/status_v2_manager.go
+++ b/internal/sheets/status_v2_manager.go
@@ -7,7 +7,7 @@ import (
 
 	"torn_rw_stats/internal/app"
 
-	"github.com/rs/zerolog/log"
+	"log/slog"
 )
 
 // StatusV2Manager handles Status v2 sheets for faction monitoring
@@ -33,10 +33,9 @@ func (m *StatusV2Manager) EnsureStatusV2Sheet(ctx context.Context, spreadsheetID
 	}
 
 	if !exists {
-		log.Info().
-			Str("sheet_name", sheetName).
-			Int("faction_id", factionID).
-			Msg("Creating Status v2 sheet")
+		slog.Info("Creating Status v2 sheet",
+			"sheet_name", sheetName,
+			"faction_id", factionID)
 
 		if err := m.api.CreateSheet(ctx, spreadsheetID, sheetName); err != nil {
 			return "", fmt.Errorf("failed to create Status v2 sheet: %w", err)
@@ -65,9 +64,8 @@ func (m *StatusV2Manager) InitializeStatusV2Sheet(ctx context.Context, spreadshe
 		return fmt.Errorf("failed to write Status v2 headers: %w", err)
 	}
 
-	log.Debug().
-		Str("sheet_name", sheetName).
-		Msg("Initialized Status v2 sheet with headers")
+	slog.Debug("Initialized Status v2 sheet with headers",
+		"sheet_name", sheetName)
 
 	return nil
 }
@@ -94,9 +92,8 @@ func (m *StatusV2Manager) GenerateStatusV2Headers() [][]interface{} {
 // UpdateStatusV2 updates the Status v2 sheet with current state record data
 func (m *StatusV2Manager) UpdateStatusV2(ctx context.Context, spreadsheetID, sheetName string, records []app.StatusV2Record) error {
 	if len(records) == 0 {
-		log.Debug().
-			Str("sheet_name", sheetName).
-			Msg("No Status v2 records to update")
+		slog.Debug("No Status v2 records to update",
+			"sheet_name", sheetName)
 		return nil
 	}
 
@@ -130,16 +127,14 @@ func (m *StatusV2Manager) UpdateStatusV2(ctx context.Context, spreadsheetID, she
 	// Apply formatting after data is added
 	if err := m.api.FormatStatusSheet(ctx, spreadsheetID, sheetName); err != nil {
 		// Log error but don't fail - formatting is nice-to-have
-		log.Warn().
-			Err(err).
-			Str("sheet_name", sheetName).
-			Msg("Failed to apply formatting to Status v2 sheet")
+		slog.Warn("Failed to apply formatting to Status v2 sheet",
+			"err", err,
+			"sheet_name", sheetName)
 	}
 
-	log.Info().
-		Str("sheet_name", sheetName).
-		Int("records_updated", len(records)).
-		Msg("Updated Status v2 sheet")
+	slog.Info("Updated Status v2 sheet",
+		"sheet_name", sheetName,
+		"records_updated", len(records))
 
 	return nil
 }

--- a/internal/sheets/war_manager.go
+++ b/internal/sheets/war_manager.go
@@ -6,7 +6,7 @@ import (
 
 	"torn_rw_stats/internal/app"
 
-	"github.com/rs/zerolog/log"
+	"log/slog"
 )
 
 // WarSheetsManager handles business logic for war sheet management
@@ -27,11 +27,10 @@ func (m *WarSheetsManager) EnsureWarSheets(ctx context.Context, spreadsheetID st
 	summaryTabName := m.GenerateSummaryTabName(war.ID)
 	recordsTabName := m.GenerateRecordsTabName(war.ID)
 
-	log.Debug().
-		Int("war_id", war.ID).
-		Str("summary_tab", summaryTabName).
-		Str("records_tab", recordsTabName).
-		Msg("Ensuring war sheets exist")
+	slog.Debug("Ensuring war sheets exist",
+		"war_id", war.ID,
+		"summary_tab", summaryTabName,
+		"records_tab", recordsTabName)
 
 	// Check if summary sheet exists
 	summaryExists, err := m.api.SheetExists(ctx, spreadsheetID, summaryTabName)
@@ -40,9 +39,8 @@ func (m *WarSheetsManager) EnsureWarSheets(ctx context.Context, spreadsheetID st
 	}
 
 	if !summaryExists {
-		log.Info().
-			Str("sheet_name", summaryTabName).
-			Msg("Creating summary sheet")
+		slog.Info("Creating summary sheet",
+			"sheet_name", summaryTabName)
 
 		if err := m.api.CreateSheet(ctx, spreadsheetID, summaryTabName); err != nil {
 			return nil, fmt.Errorf("failed to create summary sheet: %w", err)
@@ -61,9 +59,8 @@ func (m *WarSheetsManager) EnsureWarSheets(ctx context.Context, spreadsheetID st
 	}
 
 	if !recordsExists {
-		log.Info().
-			Str("sheet_name", recordsTabName).
-			Msg("Creating records sheet")
+		slog.Info("Creating records sheet",
+			"sheet_name", recordsTabName)
 
 		if err := m.api.CreateSheet(ctx, spreadsheetID, recordsTabName); err != nil {
 			return nil, fmt.Errorf("failed to create records sheet: %w", err)
@@ -102,10 +99,9 @@ func (m *WarSheetsManager) InitializeSummarySheet(ctx context.Context, spreadshe
 		return fmt.Errorf("failed to write summary headers: %w", err)
 	}
 
-	log.Debug().
-		Str("sheet_name", sheetName).
-		Int("header_rows", len(headers)).
-		Msg("Initialized summary sheet with headers")
+	slog.Debug("Initialized summary sheet with headers",
+		"sheet_name", sheetName,
+		"header_rows", len(headers))
 
 	return nil
 }
@@ -149,10 +145,9 @@ func (m *WarSheetsManager) InitializeRecordsSheet(ctx context.Context, spreadshe
 		return fmt.Errorf("failed to write records headers: %w", err)
 	}
 
-	log.Debug().
-		Str("sheet_name", sheetName).
-		Int("header_columns", len(headers[0])).
-		Msg("Initialized records sheet with headers")
+	slog.Debug("Initialized records sheet with headers",
+		"sheet_name", sheetName,
+		"header_columns", len(headers[0]))
 
 	return nil
 }
@@ -215,11 +210,10 @@ func (m *WarSheetsManager) UpdateWarSummary(ctx context.Context, spreadsheetID s
 		return fmt.Errorf("failed to update war summary: %w", err)
 	}
 
-	log.Debug().
-		Int("war_id", config.WarID).
-		Str("sheet_name", config.SummaryTabName).
-		Int("data_rows", len(summaryData)).
-		Msg("Updated war summary sheet")
+	slog.Debug("Updated war summary sheet",
+		"war_id", config.WarID,
+		"sheet_name", config.SummaryTabName,
+		"data_rows", len(summaryData))
 
 	return nil
 }

--- a/internal/torn/client.go
+++ b/internal/torn/client.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"torn_rw_stats/internal/app"
+	"log/slog"
 
-	"github.com/rs/zerolog/log"
+	"torn_rw_stats/internal/app"
 )
 
 const (
@@ -69,10 +69,9 @@ func (c *Client) makeAPIRequest(ctx context.Context, url string) (*http.Response
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		log.Debug().
-			Err(err).
-			Str("url", url).
-			Msg("API request failed")
+		slog.Debug("API request failed",
+			"err", err,
+			"url", url)
 		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 
@@ -101,7 +100,7 @@ func (c *Client) handleAPIResponse(resp *http.Response) ([]byte, error) {
 func (c *Client) GetFactionWars(ctx context.Context) (*app.WarResponse, error) {
 	url := fmt.Sprintf("https://api.torn.com/v2/faction/wars?key=%s", c.apiKey)
 
-	log.Debug().Str("url", url).Msg("Fetching faction wars")
+	slog.Debug("Fetching faction wars", "url", url)
 
 	resp, err := c.makeAPIRequest(ctx, url)
 	if err != nil {
@@ -118,11 +117,10 @@ func (c *Client) GetFactionWars(ctx context.Context) (*app.WarResponse, error) {
 		return nil, fmt.Errorf("failed to decode war response: %w", err)
 	}
 
-	log.Debug().
-		Bool("has_ranked_war", warResponse.Wars.Ranked != nil).
-		Int("raid_wars", len(warResponse.Wars.Raids)).
-		Int("territory_wars", len(warResponse.Wars.Territory)).
-		Msg("Successfully fetched faction wars")
+	slog.Debug("Successfully fetched faction wars",
+		"has_ranked_war", warResponse.Wars.Ranked != nil,
+		"raid_wars", len(warResponse.Wars.Raids),
+		"territory_wars", len(warResponse.Wars.Territory))
 
 	return &warResponse, nil
 }
@@ -131,13 +129,12 @@ func (c *Client) GetFactionWars(ctx context.Context) (*app.WarResponse, error) {
 func (c *Client) GetFactionAttacks(ctx context.Context, from, to int64) (*app.AttackResponse, error) {
 	url := fmt.Sprintf("https://api.torn.com/v2/faction/attacks?key=%s&from=%d&to=%d", c.apiKey, from, to)
 
-	log.Debug().
-		Str("url", url).
-		Int64("from", from).
-		Int64("to", to).
-		Str("from_time", time.Unix(from, 0).Format("2006-01-02 15:04:05")).
-		Str("to_time", time.Unix(to, 0).Format("2006-01-02 15:04:05")).
-		Msg("Fetching faction attacks")
+	slog.Debug("Fetching faction attacks",
+		"url", url,
+		"from", from,
+		"to", to,
+		"from_time", time.Unix(from, 0).Format("2006-01-02 15:04:05"),
+		"to_time", time.Unix(to, 0).Format("2006-01-02 15:04:05"))
 
 	resp, err := c.makeAPIRequest(ctx, url)
 	if err != nil {
@@ -154,11 +151,10 @@ func (c *Client) GetFactionAttacks(ctx context.Context, from, to int64) (*app.At
 		return nil, fmt.Errorf("failed to decode attack response: %w", err)
 	}
 
-	log.Debug().
-		Int("attacks_count", len(attackResponse.Attacks)).
-		Int64("from", from).
-		Int64("to", to).
-		Msg("Successfully fetched faction attacks")
+	slog.Debug("Successfully fetched faction attacks",
+		"attacks_count", len(attackResponse.Attacks),
+		"from", from,
+		"to", to)
 
 	return &attackResponse, nil
 }
@@ -167,10 +163,9 @@ func (c *Client) GetFactionAttacks(ctx context.Context, from, to int64) (*app.At
 func (c *Client) GetFactionBasic(ctx context.Context, factionID int) (*app.FactionBasicResponse, error) {
 	url := fmt.Sprintf("https://api.torn.com/faction/%d?selections=basic&key=%s", factionID, c.apiKey)
 
-	log.Debug().
-		Str("url", url).
-		Int("faction_id", factionID).
-		Msg("Fetching faction basic data")
+	slog.Debug("Fetching faction basic data",
+		"url", url,
+		"faction_id", factionID)
 
 	resp, err := c.makeAPIRequest(ctx, url)
 	if err != nil {
@@ -187,10 +182,9 @@ func (c *Client) GetFactionBasic(ctx context.Context, factionID int) (*app.Facti
 		return nil, fmt.Errorf("failed to decode faction response: %w", err)
 	}
 
-	log.Debug().
-		Int("faction_id", factionID).
-		Int("members_count", len(factionResponse.Members)).
-		Msg("Successfully fetched faction basic data")
+	slog.Debug("Successfully fetched faction basic data",
+		"faction_id", factionID,
+		"members_count", len(factionResponse.Members))
 
 	return &factionResponse, nil
 }
@@ -199,9 +193,7 @@ func (c *Client) GetFactionBasic(ctx context.Context, factionID int) (*app.Facti
 func (c *Client) GetOwnFaction(ctx context.Context) (*app.FactionInfoResponse, error) {
 	url := fmt.Sprintf("https://api.torn.com/faction/?selections=basic&key=%s", c.apiKey)
 
-	log.Debug().
-		Str("url", url).
-		Msg("Fetching own faction data")
+	slog.Debug("Fetching own faction data", "url", url)
 
 	resp, err := c.makeAPIRequest(ctx, url)
 	if err != nil {
@@ -218,11 +210,10 @@ func (c *Client) GetOwnFaction(ctx context.Context) (*app.FactionInfoResponse, e
 		return nil, fmt.Errorf("failed to decode faction response: %w", err)
 	}
 
-	log.Debug().
-		Int("faction_id", factionResponse.ID).
-		Str("faction_name", factionResponse.Name).
-		Str("faction_tag", factionResponse.Tag).
-		Msg("Successfully fetched own faction data")
+	slog.Debug("Successfully fetched own faction data",
+		"faction_id", factionResponse.ID,
+		"faction_name", factionResponse.Name,
+		"faction_tag", factionResponse.Tag)
 
 	return &factionResponse, nil
 }

--- a/internal/torn/processor.go
+++ b/internal/torn/processor.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"time"
 
+	"log/slog"
+
 	"torn_rw_stats/internal/app"
 	"torn_rw_stats/internal/domain/attack"
-
-	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -84,16 +84,15 @@ func (p *AttackProcessor) GetAttacksForTimeRange(ctx context.Context, war *app.W
 
 	// Log strategy and estimated API calls for observability
 	estimatedCalls := attack.EstimateAPICallsRequired(strategy)
-	log.Info().
-		Int("war_id", war.ID).
-		Str("update_mode", timeRange.UpdateMode).
-		Str("fetch_strategy", string(strategy.Method)).
-		Int("estimated_api_calls", estimatedCalls).
-		Int64("fetch_from", timeRange.FromTime).
-		Int64("fetch_to", timeRange.ToTime).
-		Str("fetch_from_str", startTime.Format("2006-01-02 15:04:05")).
-		Str("fetch_to_str", endTime.Format("2006-01-02 15:04:05")).
-		Msg("Fetching attacks for war")
+	slog.Info("Fetching attacks for war",
+		"war_id", war.ID,
+		"update_mode", timeRange.UpdateMode,
+		"fetch_strategy", string(strategy.Method),
+		"estimated_api_calls", estimatedCalls,
+		"fetch_from", timeRange.FromTime,
+		"fetch_to", timeRange.ToTime,
+		"fetch_from_str", startTime.Format("2006-01-02 15:04:05"),
+		"fetch_to_str", endTime.Format("2006-01-02 15:04:05"))
 
 	// Imperative shell: Execute the strategy
 	return p.executeFetchStrategy(ctx, war, timeRange, strategy)
@@ -101,7 +100,7 @@ func (p *AttackProcessor) GetAttacksForTimeRange(ctx context.Context, war *app.W
 
 // fetchAttacksSimple fetches attacks using a single API call (for small time ranges)
 func (p *AttackProcessor) fetchAttacksSimple(ctx context.Context, war *app.War, timeRange TimeRange) ([]app.Attack, error) {
-	log.Debug().Msg("Using simple API call for incremental update")
+	slog.Debug("Using simple API call for incremental update")
 
 	attackResp, err := p.api.GetFactionAttacks(ctx, timeRange.FromTime, timeRange.ToTime)
 	if err != nil {
@@ -113,11 +112,10 @@ func (p *AttackProcessor) fetchAttacksSimple(ctx context.Context, war *app.War, 
 	filtered := attack.FilterRelevantAttacks(attackResp.Attacks, warFactionIDs)
 	allAttacks := attack.SortAttacksChronologically(filtered)
 
-	log.Info().
-		Int("total_relevant_attacks", len(allAttacks)).
-		Int("war_id", war.ID).
-		Str("mode", "incremental_simple").
-		Msg("Completed fetching attacks for war")
+	slog.Info("Completed fetching attacks for war",
+		"total_relevant_attacks", len(allAttacks),
+		"war_id", war.ID,
+		"mode", "incremental_simple")
 
 	return allAttacks, nil
 }
@@ -145,31 +143,28 @@ func (p *AttackProcessor) fetchAttacksPaginated(ctx context.Context, war *app.Wa
 		// Set up next page
 		currentTo = pageResult.OldestAttackTime - 1
 
-		log.Debug().
-			Int64("next_to", currentTo).
-			Str("next_to_str", time.Unix(currentTo, 0).Format("2006-01-02 15:04:05")).
-			Int("total_attacks_so_far", len(allAttacks)).
-			Msg("Preparing next pagination request")
+		slog.Debug("Preparing next pagination request",
+			"next_to", currentTo,
+			"next_to_str", time.Unix(currentTo, 0).Format("2006-01-02 15:04:05"),
+			"total_attacks_so_far", len(allAttacks))
 	}
 
 	// Sort all attacks chronologically (oldest first) for consistent sheet ordering
 	allAttacks = attack.SortAttacksChronologically(allAttacks)
 
-	log.Info().
-		Int("total_relevant_attacks", len(allAttacks)).
-		Int("war_id", war.ID).
-		Str("mode", timeRange.UpdateMode+"_paginated").
-		Msg("Completed fetching attacks for war")
+	slog.Info("Completed fetching attacks for war",
+		"total_relevant_attacks", len(allAttacks),
+		"war_id", war.ID,
+		"mode", timeRange.UpdateMode+"_paginated")
 
 	return allAttacks, nil
 }
 
 // fetchAttacksPage fetches and processes a single page of attacks
 func (p *AttackProcessor) fetchAttacksPage(ctx context.Context, war *app.War, fromTime, currentTo int64) (*PageResult, error) {
-	log.Debug().
-		Int64("current_to", currentTo).
-		Str("current_to_str", time.Unix(currentTo, 0).Format("2006-01-02 15:04:05")).
-		Msg("Fetching attacks page (backwards pagination)")
+	slog.Debug("Fetching attacks page (backwards pagination)",
+		"current_to", currentTo,
+		"current_to_str", time.Unix(currentTo, 0).Format("2006-01-02 15:04:05"))
 
 	// Fetch attacks up to currentTo timestamp
 	attackResp, err := p.api.GetFactionAttacks(ctx, fromTime, currentTo)
@@ -177,9 +172,8 @@ func (p *AttackProcessor) fetchAttacksPage(ctx context.Context, war *app.War, fr
 		return nil, fmt.Errorf("failed to fetch attacks for timeframe %d-%d: %w", fromTime, currentTo, err)
 	}
 
-	log.Debug().
-		Int("attacks_in_page", len(attackResp.Attacks)).
-		Msg("Received attacks from API")
+	slog.Debug("Received attacks from API",
+		"attacks_in_page", len(attackResp.Attacks))
 
 	// Process the page
 	return p.processAttacksPage(attackResp.Attacks, war, currentTo), nil
@@ -191,11 +185,10 @@ func (p *AttackProcessor) processAttacksPage(attacks []app.Attack, war *app.War,
 	relevantAttacks := attack.FilterRelevantAttacks(attacks, warFactionIDs)
 	oldestAttackTime := attack.FindOldestAttackTime(attacks, currentTo)
 
-	log.Debug().
-		Int("relevant_attacks_in_page", len(relevantAttacks)).
-		Int64("oldest_attack_time", oldestAttackTime).
-		Str("oldest_attack_str", time.Unix(oldestAttackTime, 0).Format("2006-01-02 15:04:05")).
-		Msg("Filtered attacks for war relevance")
+	slog.Debug("Filtered attacks for war relevance",
+		"relevant_attacks_in_page", len(relevantAttacks),
+		"oldest_attack_time", oldestAttackTime,
+		"oldest_attack_str", time.Unix(oldestAttackTime, 0).Format("2006-01-02 15:04:05"))
 
 	return &PageResult{
 		RelevantAttacks:   relevantAttacks,
@@ -233,16 +226,14 @@ func (p *AttackProcessor) shouldStopPagination(pageResult *PageResult, fromTime 
 	if decision.ShouldStop {
 		switch decision.Reason {
 		case "no_more_attacks":
-			log.Debug().Msg("No more attacks returned, stopping pagination")
+			slog.Debug("No more attacks returned, stopping pagination")
 		case "partial_page":
-			log.Debug().
-				Int("attacks_received", decision.AttacksProcessed).
-				Msg("Received less than full page, stopping pagination")
+			slog.Debug("Received less than full page, stopping pagination",
+				"attacks_received", decision.AttacksProcessed)
 		case "reached_start_time":
-			log.Debug().
-				Int64("oldest_attack", decision.OldestTimestamp).
-				Int64("fetch_start", fromTime).
-				Msg("Reached fetch start time, stopping pagination")
+			slog.Debug("Reached fetch start time, stopping pagination",
+				"oldest_attack", decision.OldestTimestamp,
+				"fetch_start", fromTime)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -14,8 +15,6 @@ import (
 	"torn_rw_stats/internal/processing"
 	"torn_rw_stats/internal/sheets"
 	"torn_rw_stats/internal/torn"
-
-	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -32,15 +31,15 @@ func main() {
 	runOnce := flag.Bool("once", false, "Run once and exit (don't start scheduler)")
 	flag.Parse()
 
-	log.Info().
-		Dur("interval", *interval).
-		Bool("run_once", *runOnce).
-		Msg("Starting Torn RW Stats application")
+	slog.Info("Starting Torn RW Stats application",
+		"interval", *interval,
+		"run_once", *runOnce)
 
 	// Load configuration
 	config, err := app.LoadConfig()
 	if err != nil {
-		log.Fatal().Err(err).Msg("Failed to load configuration")
+		slog.Error("Failed to load configuration", "err", err)
+		os.Exit(1)
 	}
 
 	// Set the update interval from command line flag
@@ -54,7 +53,7 @@ func main() {
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-sigChan
-		log.Info().Msg("Shutdown signal received, stopping gracefully")
+		slog.Info("Shutdown signal received, stopping gracefully")
 		cancel()
 	}()
 
@@ -62,7 +61,8 @@ func main() {
 	tornClient := torn.NewClient(config.TornAPIKey)
 	sheetsClient, err := sheets.NewClient(ctx, config.CredentialsFile)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Failed to create sheets client")
+		slog.Error("Failed to create sheets client", "err", err)
+		os.Exit(1)
 	}
 
 	// Optionally initialize BigQuery client (disabled if BIGQUERY_PROJECT_ID is unset)
@@ -72,14 +72,13 @@ func main() {
 		bqClient, bqErr = bqclient.NewClient(ctx, config.CredentialsFile,
 			config.BigQueryProjectID, config.BigQueryDatasetID, config.BigQueryTableID)
 		if bqErr != nil {
-			log.Error().Err(bqErr).Msg("Failed to create BigQuery client — BigQuery integration disabled")
+			slog.Error("Failed to create BigQuery client — BigQuery integration disabled", "err", bqErr)
 			bqClient = nil
 		} else {
-			log.Info().
-				Str("project", config.BigQueryProjectID).
-				Str("dataset", config.BigQueryDatasetID).
-				Str("table", config.BigQueryTableID).
-				Msg("BigQuery client initialized")
+			slog.Info("BigQuery client initialized",
+				"project", config.BigQueryProjectID,
+				"dataset", config.BigQueryDatasetID,
+				"table", config.BigQueryTableID)
 		}
 	}
 
@@ -88,13 +87,13 @@ func main() {
 
 	// Define the main processing function that returns next check time
 	processWars := func() time.Duration {
-		log.Debug().Msg("Starting war processing cycle")
+		slog.Debug("Starting war processing cycle")
 
 		// Reset API call counter at the start of each cycle
 		tornClient.ResetAPICallCount()
 
 		if err := warProcessor.ProcessActiveWars(ctx); err != nil {
-			log.Error().Err(err).Msg("Failed to process active wars")
+			slog.Error("Failed to process active wars", "err", err)
 			return *interval // Use CLI interval as fallback on error
 		}
 
@@ -112,29 +111,27 @@ func main() {
 			nextCheckDuration = *interval
 		}
 
-		log.Info().
-			Int64("api_calls", apiCalls).
-			Dur("next_check_in", nextCheckDuration).
-			Msg("Completed war processing cycle")
+		slog.Info("Completed war processing cycle",
+			"api_calls", apiCalls,
+			"next_check_in", nextCheckDuration)
 
 		return nextCheckDuration
 	}
 
 	// Run initial processing
-	log.Info().Msg("Running initial war processing")
+	slog.Info("Running initial war processing")
 	nextInterval := processWars()
 
 	// Exit if run-once flag is set
 	if *runOnce {
-		log.Info().Msg("Run-once mode: exiting after initial processing")
+		slog.Info("Run-once mode: exiting after initial processing")
 		return
 	}
 
 	// Start scheduled processing with dynamic intervals
-	log.Info().
-		Dur("fallback_interval", *interval).
-		Dur("initial_next_check", nextInterval).
-		Msg("Starting scheduled war processing with intelligent timing")
+	slog.Info("Starting scheduled war processing with intelligent timing",
+		"fallback_interval", *interval,
+		"initial_next_check", nextInterval)
 
 	ticker := time.NewTicker(nextInterval)
 	defer ticker.Stop()
@@ -145,7 +142,7 @@ func main() {
 			nextInterval = processWars()
 			ticker.Reset(nextInterval)
 		case <-ctx.Done():
-			log.Info().Msg("Shutting down war processor")
+			slog.Info("Shutting down war processor")
 			return
 		}
 	}


### PR DESCRIPTION
## Summary

- Removes `github.com/rs/zerolog` software supply chain dependency entirely
- Migrates all logging across 22 files to stdlib `log/slog` (available since Go 1.21)
- `log.Fatal()` calls become `slog.Error()` + `os.Exit(1)`
- Dynamic field building in `APICallTracker.LogSessionSummary` uses `[]any` varargs
- Level management via exported `app.LogLevel slog.LevelVar` and `app.LevelDisabled` constant
- Production: JSON handler to stderr; development: text handler to stderr
- `fatal` and `panic` log levels both map to `slog.LevelError`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 11 packages)
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean
- [x] `go mod tidy` removes `zerolog` from `go.mod` / `go.sum`

🤖 Generated with [Claude Code](https://claude.com/claude-code)