### PR TITLE
chore: bump Go to 1.26.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25.1'
+        go-version: '1.26.4'
         cache: true
 
     - name: Verify dependencies
@@ -58,7 +58,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25.1'
+        go-version: '1.26.4'
 
     - name: Run Gosec Security Scanner
       uses: cosmos/gosec@master
@@ -83,7 +83,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25.1'
+        go-version: '1.26.4'
 
     - name: Build binary
       run: CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o torn_rw_stats .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,40 @@
- Build stage - Use latest .* Alpine image# Build stage - Use latest 1.26.2 Alpine image
- Build stage - Use latest .* Alpine imageFROM golang:1.26.4-alpine AS builder
- Build stage - Use latest .* Alpine image
- Build stage - Use latest .* Alpine image# Docker automatically provides these build args for multi-platform builds
- Build stage - Use latest .* Alpine imageARG TARGETOS
- Build stage - Use latest .* Alpine imageARG TARGETARCH
- Build stage - Use latest .* Alpine image
- Build stage - Use latest .* Alpine imageWORKDIR /app
- Build stage - Use latest .* Alpine image
- Build stage - Use latest .* Alpine image# Copy go mod files
- Build stage - Use latest .* Alpine imageCOPY go.mod go.sum ./
- Build stage - Use latest .* Alpine image
- Build stage - Use latest .* Alpine image# Download and verify dependencies
- Build stage - Use latest .* Alpine imageRUN go mod download && go mod verify
- Build stage - Use latest .* Alpine image
- Build stage - Use latest .* Alpine image# Copy source code
- Build stage - Use latest .* Alpine imageCOPY . .
- Build stage - Use latest .* Alpine image
- Build stage - Use latest .* Alpine image# Build the application with build info and security flags
- Build stage - Use latest .* Alpine image# Use TARGETOS and TARGETARCH instead of hardcoded values
- Build stage - Use latest .* Alpine imageRUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
- Build stage - Use latest .* Alpine image    -a \
- Build stage - Use latest .* Alpine image    -installsuffix cgo \
- Build stage - Use latest .* Alpine image    -ldflags='-w -s -extldflags "-static"' \
- Build stage - Use latest .* Alpine image    -o torn_rw_stats \
- Build stage - Use latest .* Alpine image    .
- Build stage - Use latest .* Alpine image
- Build stage - Use latest .* Alpine image# Final stage - Use distroless for security and minimal attack surface
- Build stage - Use latest .* Alpine imageFROM gcr.io/distroless/static:nonroot
- Build stage - Use latest .* Alpine image
- Build stage - Use latest .* Alpine image# Copy binary from builder stage
- Build stage - Use latest .* Alpine imageCOPY --from=builder /app/torn_rw_stats /app/torn_rw_stats
- Build stage - Use latest .* Alpine image
- Build stage - Use latest .* Alpine imageWORKDIR /app
- Build stage - Use latest .* Alpine image
- Build stage - Use latest .* Alpine image# Use built-in nonroot user (UID 65532)
- Build stage - Use latest .* Alpine imageUSER 65532:65532
- Build stage - Use latest .* Alpine image
- Build stage - Use latest .* Alpine image# Set default command
- Build stage - Use latest .* Alpine imageCMD ["./torn_rw_stats"]
+# Build stage - Use latest 1.26.4 Alpine image
+FROM golang:1.26.4-alpine AS builder
+
+# Docker automatically provides these build args for multi-platform builds
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /app
+
+# Copy go mod files
+COPY go.mod go.sum ./
+
+# Download and verify dependencies
+RUN go mod download && go mod verify
+
+# Copy source code
+COPY . .
+
+# Build the application with build info and security flags
+# Use TARGETOS and TARGETARCH instead of hardcoded values
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+    -a \
+    -installsuffix cgo \
+    -ldflags='-w -s -extldflags "-static"' \
+    -o torn_rw_stats \
+    .
+
+# Final stage - Use distroless for security and minimal attack surface
+FROM gcr.io/distroless/static:nonroot
+
+# Copy binary from builder stage
+COPY --from=builder /app/torn_rw_stats /app/torn_rw_stats
+
+WORKDIR /app
+
+# Use built-in nonroot user (UID 65532)
+USER 65532:65532
+
+# Set default command
+CMD ["./torn_rw_stats"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,40 @@
-# Build stage - Use latest 1.26.2 Alpine image
-FROM golang:1.26.2-alpine AS builder
-
-# Docker automatically provides these build args for multi-platform builds
-ARG TARGETOS
-ARG TARGETARCH
-
-WORKDIR /app
-
-# Copy go mod files
-COPY go.mod go.sum ./
-
-# Download and verify dependencies
-RUN go mod download && go mod verify
-
-# Copy source code
-COPY . .
-
-# Build the application with build info and security flags
-# Use TARGETOS and TARGETARCH instead of hardcoded values
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
-    -a \
-    -installsuffix cgo \
-    -ldflags='-w -s -extldflags "-static"' \
-    -o torn_rw_stats \
-    .
-
-# Final stage - Use distroless for security and minimal attack surface
-FROM gcr.io/distroless/static:nonroot
-
-# Copy binary from builder stage
-COPY --from=builder /app/torn_rw_stats /app/torn_rw_stats
-
-WORKDIR /app
-
-# Use built-in nonroot user (UID 65532)
-USER 65532:65532
-
-# Set default command
-CMD ["./torn_rw_stats"]
+ Build stage - Use latest .* Alpine image# Build stage - Use latest 1.26.2 Alpine image
+ Build stage - Use latest .* Alpine imageFROM golang:1.26.4-alpine AS builder
+ Build stage - Use latest .* Alpine image
+ Build stage - Use latest .* Alpine image# Docker automatically provides these build args for multi-platform builds
+ Build stage - Use latest .* Alpine imageARG TARGETOS
+ Build stage - Use latest .* Alpine imageARG TARGETARCH
+ Build stage - Use latest .* Alpine image
+ Build stage - Use latest .* Alpine imageWORKDIR /app
+ Build stage - Use latest .* Alpine image
+ Build stage - Use latest .* Alpine image# Copy go mod files
+ Build stage - Use latest .* Alpine imageCOPY go.mod go.sum ./
+ Build stage - Use latest .* Alpine image
+ Build stage - Use latest .* Alpine image# Download and verify dependencies
+ Build stage - Use latest .* Alpine imageRUN go mod download && go mod verify
+ Build stage - Use latest .* Alpine image
+ Build stage - Use latest .* Alpine image# Copy source code
+ Build stage - Use latest .* Alpine imageCOPY . .
+ Build stage - Use latest .* Alpine image
+ Build stage - Use latest .* Alpine image# Build the application with build info and security flags
+ Build stage - Use latest .* Alpine image# Use TARGETOS and TARGETARCH instead of hardcoded values
+ Build stage - Use latest .* Alpine imageRUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+ Build stage - Use latest .* Alpine image    -a \
+ Build stage - Use latest .* Alpine image    -installsuffix cgo \
+ Build stage - Use latest .* Alpine image    -ldflags='-w -s -extldflags "-static"' \
+ Build stage - Use latest .* Alpine image    -o torn_rw_stats \
+ Build stage - Use latest .* Alpine image    .
+ Build stage - Use latest .* Alpine image
+ Build stage - Use latest .* Alpine image# Final stage - Use distroless for security and minimal attack surface
+ Build stage - Use latest .* Alpine imageFROM gcr.io/distroless/static:nonroot
+ Build stage - Use latest .* Alpine image
+ Build stage - Use latest .* Alpine image# Copy binary from builder stage
+ Build stage - Use latest .* Alpine imageCOPY --from=builder /app/torn_rw_stats /app/torn_rw_stats
+ Build stage - Use latest .* Alpine image
+ Build stage - Use latest .* Alpine imageWORKDIR /app
+ Build stage - Use latest .* Alpine image
+ Build stage - Use latest .* Alpine image# Use built-in nonroot user (UID 65532)
+ Build stage - Use latest .* Alpine imageUSER 65532:65532
+ Build stage - Use latest .* Alpine image
+ Build stage - Use latest .* Alpine image# Set default command
+ Build stage - Use latest .* Alpine imageCMD ["./torn_rw_stats"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module torn_rw_stats
 
-go 1.26.2
+go 1.26.4
 
 require (
 	cloud.google.com/go/bigquery v1.75.0


### PR DESCRIPTION
Bumps go.mod, CI workflows, and Dockerfile(s) to Go 1.26.4.