### PR TITLE
feat: prune concluded wars' sheets after retention window

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,20 @@ TORN_API_KEY=your_torn_api_key
 SPREADSHEET_ID=google_sheets_id
 GOOGLE_CREDENTIALS_FILE=credentials.json
 OUR_FACTION_ID=your_faction_id  # Optional
+SHEET_RETENTION_DAYS=30         # Optional; days to keep concluded wars' sheets (default 30, 0 disables pruning)
 ```
+
+### Concluded-War Sheet Pruning
+
+Google Sheets enforces a hard 10,000,000-cell limit per workbook. Each war
+leaves behind `Summary - <id>` and `Records - <id>` sheets, so without cleanup
+the workbook eventually fills and no new war (or Status v2) sheets can be
+created. The `SheetPruner` (`internal/application/services/sheet_pruner.go`)
+runs at most once every 24h from the processing loop: it lists all sheets,
+excludes wars still present in the current Torn API response, and deletes the
+sheets of any war whose most recent recorded attack (read from its `Records`
+sheet) is older than `SHEET_RETENTION_DAYS`. Wars with no datable activity are
+never pruned.
 
 ## Development Notes
 

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -5,8 +5,11 @@ import (
 	"log/slog"
 	"math"
 	"os"
+	"strconv"
 	"strings"
 	"time"
+
+	"torn_rw_stats/internal/domain/war"
 )
 
 // Config holds application configuration
@@ -16,6 +19,10 @@ type Config struct {
 	CredentialsFile string
 	UpdateInterval  time.Duration
 	DeployURL       string
+
+	// SheetRetention is how long a concluded war's sheets are kept before they
+	// are pruned. Zero disables pruning.
+	SheetRetention time.Duration
 
 	// BigQuery integration (all optional; empty ProjectID disables BigQuery)
 	BigQueryProjectID string
@@ -104,6 +111,15 @@ func LoadConfig() (*Config, error) {
 		bigQueryTableID = "state_changes"
 	}
 
+	sheetRetention := war.DefaultSheetRetention
+	if v := os.Getenv("SHEET_RETENTION_DAYS"); v != "" {
+		days, err := strconv.Atoi(v)
+		if err != nil || days < 0 {
+			return nil, fmt.Errorf("SHEET_RETENTION_DAYS must be a non-negative integer, got %q", v)
+		}
+		sheetRetention = time.Duration(days) * 24 * time.Hour
+	}
+
 	return &Config{
 		TornAPIKey:        apiKey,
 		SpreadsheetID:     spreadsheetID,
@@ -112,6 +128,7 @@ func LoadConfig() (*Config, error) {
 		BigQueryProjectID: bigQueryProjectID,
 		BigQueryDatasetID: bigQueryDatasetID,
 		BigQueryTableID:   bigQueryTableID,
+		SheetRetention:    sheetRetention,
 	}, nil
 }
 

--- a/internal/application/ports/mocks/sheets_client.go
+++ b/internal/application/ports/mocks/sheets_client.go
@@ -21,6 +21,8 @@ type SheetsClient interface {
 	CreateSheet(ctx context.Context, spreadsheetID, sheetName string) error
 	SheetExists(ctx context.Context, spreadsheetID, sheetName string) (bool, error)
 	EnsureSheetCapacity(ctx context.Context, spreadsheetID, sheetName string, requiredRows, requiredCols int) error
+	ListSheetTitles(ctx context.Context, spreadsheetID string) ([]string, error)
+	DeleteSheet(ctx context.Context, spreadsheetID, sheetName string) error
 
 	// Status v2 methods
 	EnsureStatusV2Sheet(ctx context.Context, spreadsheetID string, factionID int) (string, error)
@@ -35,6 +37,11 @@ type MockSheetsClient struct {
 	ReadSheetResponse           [][]interface{}
 	SheetExistsResponse         bool
 	EnsureStatusV2SheetResponse string
+	ListSheetTitlesResponse     []string
+
+	// ReadExistingRecordsFunc, when set, overrides ReadExistingRecordsResponse
+	// and lets a test return a different result per sheet name.
+	ReadExistingRecordsFunc func(sheetName string) (*domain.RecordsInfo, error)
 
 	// Errors to return
 	EnsureWarSheetsError     error
@@ -50,6 +57,11 @@ type MockSheetsClient struct {
 	EnsureSheetCapacityError error
 	EnsureStatusV2SheetError error
 	UpdateStatusV2Error      error
+	ListSheetTitlesError     error
+	DeleteSheetError         error
+
+	// DeletedSheets records the names passed to DeleteSheet, in call order.
+	DeletedSheets []string
 
 	// Call tracking
 	EnsureWarSheetsCalled     bool
@@ -99,6 +111,9 @@ func (m *MockSheetsClient) ReadExistingRecords(ctx context.Context, spreadsheetI
 	m.ReadExistingRecordsCalled = true
 	m.ReadExistingRecordsCalledWith.SpreadsheetID = spreadsheetID
 	m.ReadExistingRecordsCalledWith.SheetName = sheetName
+	if m.ReadExistingRecordsFunc != nil {
+		return m.ReadExistingRecordsFunc(sheetName)
+	}
 	return m.ReadExistingRecordsResponse, m.ReadExistingRecordsError
 }
 
@@ -194,6 +209,18 @@ func (m *MockSheetsClient) SheetExists(ctx context.Context, spreadsheetID, sheet
 
 func (m *MockSheetsClient) EnsureSheetCapacity(ctx context.Context, spreadsheetID, sheetName string, requiredRows, requiredCols int) error {
 	return m.EnsureSheetCapacityError
+}
+
+func (m *MockSheetsClient) ListSheetTitles(ctx context.Context, spreadsheetID string) ([]string, error) {
+	return m.ListSheetTitlesResponse, m.ListSheetTitlesError
+}
+
+func (m *MockSheetsClient) DeleteSheet(ctx context.Context, spreadsheetID, sheetName string) error {
+	if m.DeleteSheetError != nil {
+		return m.DeleteSheetError
+	}
+	m.DeletedSheets = append(m.DeletedSheets, sheetName)
+	return nil
 }
 
 // Status v2 methods

--- a/internal/application/ports/ports.go
+++ b/internal/application/ports/ports.go
@@ -48,6 +48,10 @@ type SheetsClient interface {
 	SheetExists(ctx context.Context, spreadsheetID, sheetName string) (bool, error)
 	EnsureSheetCapacity(ctx context.Context, spreadsheetID, sheetName string, requiredRows, requiredCols int) error
 
+	// Sheet lifecycle management (used by concluded-war pruning)
+	ListSheetTitles(ctx context.Context, spreadsheetID string) ([]string, error)
+	DeleteSheet(ctx context.Context, spreadsheetID, sheetName string) error
+
 	// Status v2 methods
 	EnsureStatusV2Sheet(ctx context.Context, spreadsheetID string, factionID int) (string, error)
 	UpdateStatusV2(ctx context.Context, spreadsheetID, sheetName string, records []domain.StatusV2Record) error

--- a/internal/application/services/optimized_war_processor.go
+++ b/internal/application/services/optimized_war_processor.go
@@ -22,6 +22,7 @@ type OptimizedWarProcessor struct {
 	stateManager      *war.WarStateManager
 	stateTracker      *StateTrackingService
 	statusV2Processor *StatusV2Processor
+	pruner            *SheetPruner
 	spreadsheetID     string
 	config            *app.Config
 }
@@ -49,6 +50,9 @@ func NewOptimizedWarProcessor(
 	// Create Status v2 processor
 	statusV2Processor := NewStatusV2Processor(tornClient, sheetsClient, bqClient, deployer)
 
+	// Create the concluded-war sheet pruner
+	pruner := NewSheetPruner(sheetsClient, config.SpreadsheetID, config.SheetRetention)
+
 	// Create processor with raw client
 	processor := NewWarProcessor(
 		tornClient,
@@ -67,6 +71,7 @@ func NewOptimizedWarProcessor(
 		stateManager:      stateManager,
 		stateTracker:      stateTracker,
 		statusV2Processor: statusV2Processor,
+		pruner:            pruner,
 		spreadsheetID:     config.SpreadsheetID,
 		config:            config,
 	}
@@ -119,6 +124,10 @@ func (owp *OptimizedWarProcessor) ProcessActiveWars(ctx context.Context) error {
 
 	// Process state changes for all observed factions
 	owp.processStateChanges(ctx, warResponse, stateInfo)
+
+	// Housekeeping: prune sheets from long-concluded wars (rate-limited
+	// internally, and never touches wars still present in this response).
+	owp.pruner.MaybePrune(ctx, activeWarIDs(warResponse))
 
 	// Handle different states
 	switch currentState {
@@ -290,6 +299,22 @@ func (owp *OptimizedWarProcessor) processStateChanges(ctx context.Context, warRe
 		slog.Debug("Successfully processed Status v2",
 			"faction_ids", dashboardFactionIDs)
 	}
+}
+
+// activeWarIDs collects the IDs of all wars present in a war response. These
+// wars are still being monitored and must never be pruned.
+func activeWarIDs(warResponse *domain.FactionWars) []int {
+	var ids []int
+	if warResponse.Ranked != nil {
+		ids = append(ids, warResponse.Ranked.ID)
+	}
+	for _, w := range warResponse.Raids {
+		ids = append(ids, w.ID)
+	}
+	for _, w := range warResponse.Territory {
+		ids = append(ids, w.ID)
+	}
+	return ids
 }
 
 // removeDuplicateFactionIDs removes duplicate faction IDs from a slice

--- a/internal/application/services/sheet_pruner.go
+++ b/internal/application/services/sheet_pruner.go
@@ -1,0 +1,139 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"log/slog"
+
+	"torn_rw_stats/internal/application/ports"
+	wardomain "torn_rw_stats/internal/domain/war"
+)
+
+// pruneCheckInterval is the minimum time between prune passes. Pruning is a
+// housekeeping task with day-scale retention, so there is no reason to scan the
+// spreadsheet more than once a day.
+const pruneCheckInterval = 24 * time.Hour
+
+// SheetPruner deletes the sheets belonging to wars that concluded longer than
+// the retention window ago, keeping the workbook under Google Sheets' hard
+// 10M-cell limit. A war's "conclusion" is approximated by the timestamp of its
+// most recent recorded attack, since the app stops updating a war's sheets once
+// it drops out of the Torn API response.
+type SheetPruner struct {
+	sheets        ports.SheetsClient
+	spreadsheetID string
+	retention     time.Duration
+	interval      time.Duration
+	lastRun       time.Time
+	now           func() time.Time
+}
+
+// NewSheetPruner creates a pruner with the given retention window. A
+// non-positive retention disables pruning.
+func NewSheetPruner(sheetsClient ports.SheetsClient, spreadsheetID string, retention time.Duration) *SheetPruner {
+	return &SheetPruner{
+		sheets:        sheetsClient,
+		spreadsheetID: spreadsheetID,
+		retention:     retention,
+		interval:      pruneCheckInterval,
+		now:           time.Now,
+	}
+}
+
+// MaybePrune runs a prune pass if at least the check interval has elapsed since
+// the previous run (the first call always runs). Failures are logged and
+// swallowed so pruning never disrupts the main processing loop. activeWarIDs
+// lists wars currently being monitored; their sheets are never touched.
+func (sp *SheetPruner) MaybePrune(ctx context.Context, activeWarIDs []int) {
+	if sp.retention <= 0 {
+		return // pruning disabled
+	}
+
+	now := sp.now()
+	if !sp.lastRun.IsZero() && now.Sub(sp.lastRun) < sp.interval {
+		return
+	}
+	sp.lastRun = now
+
+	if err := sp.prune(ctx, activeWarIDs, now); err != nil {
+		slog.Error("Failed to prune concluded war sheets", "err", err)
+	}
+}
+
+// prune performs a single prune pass.
+func (sp *SheetPruner) prune(ctx context.Context, activeWarIDs []int, now time.Time) error {
+	titles, err := sp.sheets.ListSheetTitles(ctx, sp.spreadsheetID)
+	if err != nil {
+		return fmt.Errorf("failed to list sheets: %w", err)
+	}
+
+	active := make(map[int]bool, len(activeWarIDs))
+	for _, id := range activeWarIDs {
+		active[id] = true
+	}
+
+	candidates := wardomain.PrunableWarIDs(titles, active)
+	if len(candidates) == 0 {
+		slog.Debug("No concluded wars eligible for pruning")
+		return nil
+	}
+
+	slog.Info("Evaluating concluded wars for pruning",
+		"candidate_wars", len(candidates),
+		"retention", sp.retention)
+
+	pruned := 0
+	for _, warID := range candidates {
+		lastActivity, err := sp.lastActivity(ctx, warID)
+		if err != nil {
+			slog.Warn("Could not determine war activity - skipping",
+				"war_id", warID, "err", err)
+			continue
+		}
+
+		if !wardomain.ShouldPruneWar(lastActivity, now, sp.retention) {
+			continue
+		}
+
+		sp.deleteWarSheets(ctx, warID, lastActivity)
+		pruned++
+	}
+
+	slog.Info("Completed war sheet pruning",
+		"candidate_wars", len(candidates),
+		"pruned_wars", pruned)
+	return nil
+}
+
+// lastActivity returns the timestamp of a war's most recent recorded attack,
+// used as a proxy for when the war concluded. A zero time means the war's age
+// could not be established (empty or unparseable records), in which case the
+// pruning policy keeps the sheets.
+func (sp *SheetPruner) lastActivity(ctx context.Context, warID int) (time.Time, error) {
+	info, err := sp.sheets.ReadExistingRecords(ctx, sp.spreadsheetID, wardomain.RecordsSheetTitle(warID))
+	if err != nil {
+		return time.Time{}, err
+	}
+	if info == nil || info.LatestTimestamp <= 0 {
+		return time.Time{}, nil
+	}
+	return time.Unix(info.LatestTimestamp, 0).UTC(), nil
+}
+
+// deleteWarSheets removes every sheet owned by a war. Individual failures are
+// logged and do not abort the remaining deletions.
+func (sp *SheetPruner) deleteWarSheets(ctx context.Context, warID int, lastActivity time.Time) {
+	for _, title := range wardomain.WarSheetTitles(warID) {
+		if err := sp.sheets.DeleteSheet(ctx, sp.spreadsheetID, title); err != nil {
+			slog.Error("Failed to delete concluded war sheet",
+				"war_id", warID, "sheet_name", title, "err", err)
+			continue
+		}
+		slog.Info("Pruned concluded war sheet",
+			"war_id", warID,
+			"sheet_name", title,
+			"last_activity", lastActivity.Format("2006-01-02 15:04:05"))
+	}
+}

--- a/internal/application/services/sheet_pruner_test.go
+++ b/internal/application/services/sheet_pruner_test.go
@@ -1,0 +1,132 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"torn_rw_stats/internal/application/ports/mocks"
+	"torn_rw_stats/internal/domain"
+	wardomain "torn_rw_stats/internal/domain/war"
+)
+
+// recordsByWar builds a ReadExistingRecordsFunc that maps a war's records sheet
+// to a RecordsInfo whose LatestTimestamp is the given time (zero => empty).
+func recordsByWar(times map[int]time.Time) func(sheetName string) (*domain.RecordsInfo, error) {
+	return func(sheetName string) (*domain.RecordsInfo, error) {
+		for warID, t := range times {
+			if sheetName == wardomain.RecordsSheetTitle(warID) {
+				var ts int64
+				if !t.IsZero() {
+					ts = t.Unix()
+				}
+				return &domain.RecordsInfo{LatestTimestamp: ts}, nil
+			}
+		}
+		return &domain.RecordsInfo{}, nil
+	}
+}
+
+func newPrunerAt(sheetsClient *mocks.MockSheetsClient, retention time.Duration, now time.Time) *SheetPruner {
+	p := NewSheetPruner(sheetsClient, "sheet-id", retention)
+	p.now = func() time.Time { return now }
+	return p
+}
+
+func TestSheetPruner_PrunesOnlyOldConcludedWars(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	retention := 30 * 24 * time.Hour
+
+	sheetsClient := mocks.NewMockSheetsClient()
+	sheetsClient.ListSheetTitlesResponse = []string{
+		"Summary - 100", "Records - 100", // old -> prune
+		"Summary - 200", "Records - 200", // recent -> keep
+		"Summary - 300", "Records - 300", // active -> keep
+		"Status v2 - 38482", // not a war sheet
+	}
+	sheetsClient.ReadExistingRecordsFunc = recordsByWar(map[int]time.Time{
+		100: now.Add(-60 * 24 * time.Hour),
+		200: now.Add(-2 * 24 * time.Hour),
+		300: now.Add(-90 * 24 * time.Hour), // old, but active so excluded
+	})
+
+	p := newPrunerAt(sheetsClient, retention, now)
+	p.MaybePrune(context.Background(), []int{300})
+
+	want := map[string]bool{"Summary - 100": true, "Records - 100": true}
+	if len(sheetsClient.DeletedSheets) != len(want) {
+		t.Fatalf("deleted %v, want keys %v", sheetsClient.DeletedSheets, want)
+	}
+	for _, name := range sheetsClient.DeletedSheets {
+		if !want[name] {
+			t.Errorf("unexpectedly deleted %q", name)
+		}
+	}
+}
+
+func TestSheetPruner_KeepsWarsWithoutRecords(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+
+	sheetsClient := mocks.NewMockSheetsClient()
+	sheetsClient.ListSheetTitlesResponse = []string{"Summary - 100", "Records - 100"}
+	sheetsClient.ReadExistingRecordsFunc = recordsByWar(map[int]time.Time{
+		100: {}, // empty records -> unknown age -> keep
+	})
+
+	p := newPrunerAt(sheetsClient, 30*24*time.Hour, now)
+	p.MaybePrune(context.Background(), nil)
+
+	if len(sheetsClient.DeletedSheets) != 0 {
+		t.Errorf("expected nothing pruned, deleted %v", sheetsClient.DeletedSheets)
+	}
+}
+
+func TestSheetPruner_RateLimited(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+
+	sheetsClient := mocks.NewMockSheetsClient()
+	sheetsClient.ListSheetTitlesResponse = []string{"Summary - 100", "Records - 100"}
+	sheetsClient.ReadExistingRecordsFunc = recordsByWar(map[int]time.Time{
+		100: now.Add(-60 * 24 * time.Hour),
+	})
+
+	p := newPrunerAt(sheetsClient, 30*24*time.Hour, now)
+
+	p.MaybePrune(context.Background(), nil) // runs
+	if len(sheetsClient.DeletedSheets) != 2 {
+		t.Fatalf("first run should prune war 100, deleted %v", sheetsClient.DeletedSheets)
+	}
+
+	// Advance only an hour; the next call must be skipped.
+	p.now = func() time.Time { return now.Add(time.Hour) }
+	p.MaybePrune(context.Background(), nil)
+	if len(sheetsClient.DeletedSheets) != 2 {
+		t.Errorf("second run within interval should be a no-op, deleted %v", sheetsClient.DeletedSheets)
+	}
+
+	// Advance past the interval; it runs again (sheets already gone, so no
+	// new deletions occur because the titles list no longer includes them).
+	sheetsClient.ListSheetTitlesResponse = nil
+	p.now = func() time.Time { return now.Add(25 * time.Hour) }
+	p.MaybePrune(context.Background(), nil)
+	if len(sheetsClient.DeletedSheets) != 2 {
+		t.Errorf("expected no further deletions, deleted %v", sheetsClient.DeletedSheets)
+	}
+}
+
+func TestSheetPruner_DisabledWhenRetentionZero(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+
+	sheetsClient := mocks.NewMockSheetsClient()
+	sheetsClient.ListSheetTitlesResponse = []string{"Summary - 100", "Records - 100"}
+	sheetsClient.ReadExistingRecordsFunc = recordsByWar(map[int]time.Time{
+		100: now.Add(-365 * 24 * time.Hour),
+	})
+
+	p := newPrunerAt(sheetsClient, 0, now)
+	p.MaybePrune(context.Background(), nil)
+
+	if len(sheetsClient.DeletedSheets) != 0 {
+		t.Errorf("pruning disabled, but deleted %v", sheetsClient.DeletedSheets)
+	}
+}

--- a/internal/domain/war/sheets.go
+++ b/internal/domain/war/sheets.go
@@ -1,0 +1,79 @@
+package war
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DefaultSheetRetention is how long a war's sheets are kept after the war's
+// last recorded activity before they become eligible for pruning.
+const DefaultSheetRetention = 30 * 24 * time.Hour
+
+// Per-war sheet title prefixes. These are the canonical naming convention for
+// the sheets a single war owns; the sheets adapter builds titles via
+// SummarySheetTitle / RecordsSheetTitle so this package is the single source of
+// truth for the format, which lets us reliably parse war IDs back out.
+const (
+	summarySheetPrefix = "Summary - "
+	recordsSheetPrefix = "Records - "
+)
+
+// SummarySheetTitle returns the summary sheet title for a war.
+func SummarySheetTitle(warID int) string {
+	return fmt.Sprintf("%s%d", summarySheetPrefix, warID)
+}
+
+// RecordsSheetTitle returns the records sheet title for a war.
+func RecordsSheetTitle(warID int) string {
+	return fmt.Sprintf("%s%d", recordsSheetPrefix, warID)
+}
+
+// WarSheetTitles returns every per-war sheet title owned by a war, in a stable
+// order. These are the sheets pruning deletes together.
+func WarSheetTitles(warID int) []string {
+	return []string{SummarySheetTitle(warID), RecordsSheetTitle(warID)}
+}
+
+// ParseWarSheetTitle returns the war ID encoded in a per-war sheet title
+// ("Summary - 45796" or "Records - 45796") and whether the title matched.
+func ParseWarSheetTitle(title string) (warID int, ok bool) {
+	for _, prefix := range []string{summarySheetPrefix, recordsSheetPrefix} {
+		if suffix, found := strings.CutPrefix(title, prefix); found {
+			if id, err := strconv.Atoi(strings.TrimSpace(suffix)); err == nil {
+				return id, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// PrunableWarIDs returns the distinct war IDs that own per-war sheets in titles,
+// excluding any war IDs in the active set. A war that is still being monitored
+// must never be pruned, so its ID is filtered out even if its sheets appear.
+// The result is ordered by first appearance for deterministic behaviour.
+func PrunableWarIDs(titles []string, active map[int]bool) []int {
+	seen := make(map[int]bool)
+	var ids []int
+	for _, title := range titles {
+		id, ok := ParseWarSheetTitle(title)
+		if !ok || active[id] || seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// ShouldPruneWar reports whether a war whose last recorded activity was at
+// lastActivity should have its sheets pruned as of now, given the retention
+// window. A zero lastActivity means the war's age cannot be established, so it
+// is kept (fail safe: never delete a war we can't date).
+func ShouldPruneWar(lastActivity, now time.Time, retention time.Duration) bool {
+	if lastActivity.IsZero() {
+		return false
+	}
+	return now.Sub(lastActivity) > retention
+}

--- a/internal/domain/war/sheets_test.go
+++ b/internal/domain/war/sheets_test.go
@@ -1,0 +1,104 @@
+package war
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSheetTitleRoundTrip(t *testing.T) {
+	for _, warID := range []int{1, 45796, 999999} {
+		if got, ok := ParseWarSheetTitle(SummarySheetTitle(warID)); !ok || got != warID {
+			t.Errorf("summary round-trip for %d: got (%d, %v)", warID, got, ok)
+		}
+		if got, ok := ParseWarSheetTitle(RecordsSheetTitle(warID)); !ok || got != warID {
+			t.Errorf("records round-trip for %d: got (%d, %v)", warID, got, ok)
+		}
+	}
+}
+
+func TestParseWarSheetTitle_NonMatching(t *testing.T) {
+	cases := []string{
+		"Status v2 - 40692",
+		"Summary",
+		"Summary - ",
+		"Summary - abc",
+		"Records - 12x",
+		"Sheet1",
+		"",
+	}
+	for _, title := range cases {
+		if _, ok := ParseWarSheetTitle(title); ok {
+			t.Errorf("expected %q to not parse as a war sheet", title)
+		}
+	}
+}
+
+func TestWarSheetTitles(t *testing.T) {
+	got := WarSheetTitles(45796)
+	want := []string{"Summary - 45796", "Records - 45796"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d titles, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("title[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestPrunableWarIDs(t *testing.T) {
+	titles := []string{
+		"Summary - 100",
+		"Records - 100",
+		"Summary - 200",
+		"Records - 200",
+		"Status v2 - 38482", // not a war sheet
+		"Summary - 300",     // active, must be excluded
+		"Records - 300",
+		"Config", // unrelated
+	}
+	active := map[int]bool{300: true}
+
+	got := PrunableWarIDs(titles, active)
+	want := []int{100, 200}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestPrunableWarIDs_Empty(t *testing.T) {
+	if got := PrunableWarIDs(nil, nil); len(got) != 0 {
+		t.Errorf("expected no candidates, got %v", got)
+	}
+}
+
+func TestShouldPruneWar(t *testing.T) {
+	now := time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC)
+	retention := 30 * 24 * time.Hour
+
+	tests := []struct {
+		name         string
+		lastActivity time.Time
+		want         bool
+	}{
+		{"zero time is kept", time.Time{}, false},
+		{"just concluded", now.Add(-time.Hour), false},
+		{"exactly at retention edge", now.Add(-retention), false},
+		{"one second past retention", now.Add(-retention - time.Second), true},
+		{"long concluded", now.Add(-90 * 24 * time.Hour), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldPruneWar(tt.lastActivity, now, retention); got != tt.want {
+				t.Errorf("ShouldPruneWar(%v) = %v, want %v", tt.lastActivity, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sheets/client.go
+++ b/internal/sheets/client.go
@@ -122,6 +122,63 @@ func (c *Client) CreateSheet(ctx context.Context, spreadsheetID, sheetName strin
 	return nil
 }
 
+// ListSheetTitles returns the titles of every sheet in the spreadsheet.
+func (c *Client) ListSheetTitles(ctx context.Context, spreadsheetID string) ([]string, error) {
+	spreadsheet, err := c.service.Spreadsheets.Get(spreadsheetID).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get spreadsheet: %w", err)
+	}
+
+	titles := make([]string, 0, len(spreadsheet.Sheets))
+	for _, sheet := range spreadsheet.Sheets {
+		titles = append(titles, sheet.Properties.Title)
+	}
+
+	return titles, nil
+}
+
+// DeleteSheet removes the sheet with the given name from the spreadsheet.
+// Deleting a sheet that does not exist is a no-op so the operation is
+// idempotent.
+func (c *Client) DeleteSheet(ctx context.Context, spreadsheetID, sheetName string) error {
+	spreadsheet, err := c.service.Spreadsheets.Get(spreadsheetID).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("failed to get spreadsheet: %w", err)
+	}
+
+	var sheetID int64 = -1
+	for _, sheet := range spreadsheet.Sheets {
+		if sheet.Properties.Title == sheetName {
+			sheetID = sheet.Properties.SheetId
+			break
+		}
+	}
+
+	if sheetID == -1 {
+		slog.Debug("Sheet not found, nothing to delete", "sheet_name", sheetName)
+		return nil
+	}
+
+	req := &sheets.Request{
+		DeleteSheet: &sheets.DeleteSheetRequest{
+			SheetId: sheetID,
+		},
+	}
+
+	batchUpdate := &sheets.BatchUpdateSpreadsheetRequest{
+		Requests: []*sheets.Request{req},
+	}
+
+	_, err = c.service.Spreadsheets.BatchUpdate(spreadsheetID, batchUpdate).
+		Context(ctx).
+		Do()
+	if err != nil {
+		return fmt.Errorf("failed to delete sheet %s: %w", sheetName, err)
+	}
+
+	return nil
+}
+
 // SheetExists checks if a sheet with the given name exists in the spreadsheet
 func (c *Client) SheetExists(ctx context.Context, spreadsheetID, sheetName string) (bool, error) {
 	spreadsheet, err := c.service.Spreadsheets.Get(spreadsheetID).Context(ctx).Do()

--- a/internal/sheets/war_manager.go
+++ b/internal/sheets/war_manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"torn_rw_stats/internal/domain"
+	wardomain "torn_rw_stats/internal/domain/war"
 
 	"log/slog"
 )
@@ -82,12 +83,12 @@ func (m *WarSheetsManager) EnsureWarSheets(ctx context.Context, spreadsheetID st
 
 // GenerateSummaryTabName creates a standardized summary tab name for a war
 func (m *WarSheetsManager) GenerateSummaryTabName(warID int) string {
-	return fmt.Sprintf("Summary - %d", warID)
+	return wardomain.SummarySheetTitle(warID)
 }
 
 // GenerateRecordsTabName creates a standardized records tab name for a war
 func (m *WarSheetsManager) GenerateRecordsTabName(warID int) string {
-	return fmt.Sprintf("Records - %d", warID)
+	return wardomain.RecordsSheetTitle(warID)
 }
 
 // InitializeSummarySheet sets up headers and initial content for a summary sheet


### PR DESCRIPTION
## Problem

Google Sheets enforces a hard **10,000,000-cell-per-workbook** limit. Every war leaves behind `Summary - <id>` and `Records - <id>` sheets, so over time the workbook fills up. Once it does, the app can no longer create sheets for new wars or Status v2 and silently no-op's every cycle with a `badRequest` cell-limit error — which is exactly what we hit in production.

## Change

Add a `SheetPruner` that runs **at most once per 24h** from the processing loop (and once on startup). Each pass:

1. Lists all sheets in the workbook.
2. **Excludes any war still present in the current Torn API response** — active wars are never touched.
3. Deletes the `Summary`/`Records` sheets of any war whose **most recent recorded attack** is older than the retention window.

The last-attack timestamp (read from the war's `Records` sheet) is used as the conclusion proxy, because the app stops updating a war's sheets once it drops out of the API — so the `End Time` cell stays `"Ongoing"` and can't be used. Wars with no datable activity are **kept** (fail safe: never delete what we can't date).

## Config

- `SHEET_RETENTION_DAYS` — optional, default **30**, `0` disables pruning.

## Notes

- Sheet-title construction/parsing is centralized in `internal/domain/war` as the single source of truth; `war_manager` now delegates to it, which is what lets the pruner reliably recover war IDs from titles.
- Pure policy (`ParseWarSheetTitle`, `PrunableWarIDs`, `ShouldPruneWar`) and the pruner service are unit-tested; the port mock gains `ListSheetTitles`/`DeleteSheet`.
- Costs ~1 extra API read per stale war per day.

## Validation

`go build`, `go test ./...`, `go vet`, `gofmt`, and `golangci-lint` all clean (no new lint findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)