### PR TITLE
Fix travel issue in tactical dashboard

### DIFF
--- a/internal/application/services/status_v2_travel.go
+++ b/internal/application/services/status_v2_travel.go
@@ -62,7 +62,7 @@ func (s *StatusV2Service) calculateArrivalTimes(ctx context.Context, stateRecord
 	}
 
 	existingArrival := ""
-	if existing != nil {
+	if existing != nil && existing.Departure == departure {
 		existingArrival = existing.Arrival
 	}
 
@@ -90,10 +90,11 @@ func (s *StatusV2Service) applyManualAdjustments(existing *domain.StatusV2Record
 		return calculated
 	}
 
-	result := calculated
-	if existing.Departure != "" {
-		result.Departure = existing.Departure
+	if existing.Departure != calculated.Departure {
+		return calculated
 	}
+
+	result := calculated
 	if existing.Arrival != "" {
 		result.Arrival = existing.Arrival
 	}


### PR DESCRIPTION
Prevents stale travel data from being preserved across different trips by ensuring Arrival and BusinessArrival are only kept if the Departure time is unchanged. This fixes the issue where members traveling to new destinations were still shown as traveling to previous ones.