### PR TITLE
Bump Go version to 1.26.5

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -143,7 +143,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.26.5'
 
     - name: Run GoReleaser (Tagged Release)
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.26.4'
+        go-version: '1.26.5'
         cache: true
 
     - name: Verify dependencies
@@ -58,7 +58,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.26.4'
+        go-version: '1.26.5'
 
     - name: Run Gosec Security Scanner
       uses: cosmos/gosec@master
@@ -83,7 +83,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.26.4'
+        go-version: '1.26.5'
 
     - name: Build binary
       run: CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o torn_rw_stats .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Build stage - Use latest 1.26.4 Alpine image
-FROM golang:1.26.4-alpine AS builder
+# Build stage - Use latest 1.26.5 Alpine image
+FROM golang:1.26.5-alpine AS builder
 
 # Docker automatically provides these build args for multi-platform builds
 ARG TARGETOS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module torn_rw_stats
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cloud.google.com/go/bigquery v1.77.0


### PR DESCRIPTION
Bumps Go version across the repository to 1.26.5 to resolve security vulnerability CVE-2026-39822 (os: Go os.Root: Symlink following vulnerability allows directory traversal) which was causing the container build to fail.